### PR TITLE
Modularização de rotas com APIRouter

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,14 @@
 from fastapi import FastAPI
 from app.routers import health
 
-app = FastAPI(title="SafeStreets API", description="API para o projeto SafeStreets", version="1.0.0")
+app = FastAPI(
+    title="SafeStreets API",
+    description="API para o projeto SafeStreets."
+)
 
+# Inclui o router health
 app.include_router(health.router)
 
+@app.get("/")
+async def root():
+    return {"message": "Bem-vindo ao Backend do SafeStreets!"}


### PR DESCRIPTION
## Descrição
Este PR inicia a modularização da nossa API no FastAPI. A rota principal de verificação de status (`/health`) foi movida do `main.py` para um módulo dedicado em `app/routers/health.py` utilizando o `APIRouter`. O `main.py` agora serve apenas como ponto de entrada e registro das rotas, deixando a arquitetura preparada e escalável para recebermos os próximos endpoints do projeto sem gerar conflitos.

## Tipo de mudança
- [ ] Bug fix
- [ ] Nova funcionalidade
- [x] Refatoração
- [ ] Documentação
- [ ] Melhoria de performance
- [ ] Testes

## Issue relacionada
Closes #40

## Como testar
Passo a passo para validar localmente:
1. Faça o fetch e mude para esta branch: `git fetch && git checkout feat/modularizacao-rotas`
2. Entre na pasta do backend: `cd backend`
3. Ative seu ambiente virtual e instale os requisitos (caso ainda não tenha feito): `pip install -r requirements.txt`
4. Suba o servidor Uvicorn: `python3 -m uvicorn app.main:app --reload`
5. Acesse `http://127.0.0.1:8000/health` e verifique se o JSON de sucesso (`{"status": "ok"...}`) é retornado.

## Evidências (se aplicável)
<img width="854" height="256" alt="image" src="https://github.com/user-attachments/assets/11b4a0bd-ec37-48bb-b497-0f89418ee3d4" />

---

<img width="887" height="287" alt="image" src="https://github.com/user-attachments/assets/7c163a0f-bab4-4181-a1dc-debe5fec6849" />


## Impactos e riscos
**Risco Baixo.** Tratou-se de uma refatoração da estrutura inicial do backend. O projeto ainda não possui integração com banco de dados ou frontend operando sobre essa rota, portanto não há risco de quebra de funcionalidades externas.

## Checklist
- [x] Código segue o padrão do projeto
- [ ] Testes adicionados/atualizados (se necessário)
- [x] Testado localmente
- [ ] Documentação atualizada (se necessário)

## Observações adicionais
- O retorno `404 Not Found` no terminal referente ao `favicon.ico` é esperado e normal nesta etapa, pois ainda não configuramos um ícone estático para a API.