### PR TITLE
Atualização de  gatilhos da action para rodar no push

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,7 +1,11 @@
 name: Gerar Metricas de Produtividade
 on:
+  push:
+    branches:
+      - main  # Toda vez que entrar código novo na main, ele atualiza o gráfico
+  workflow_dispatch: # Mantém o botão manual que você usou
   schedule:
-    - cron: '0 3 * * 0'
+    - cron: '0 0 * * *' # Roda também todo dia à meia-noite por segurança
   workflow_dispatch:
 permissions:
   contents: write


### PR DESCRIPTION
### **Descrição**

Este PR ajusta os gatilhos (triggers) do GitHub Actions para o dashboard de produtividade. Agora, o workflow será disparado automaticamente sempre que houver um `push` na branch `main`, garantindo que os gráficos reflitam as mudanças em tempo real. Também adicionei um agendamento diário (cron) à meia-noite como backup.

## Tipo de mudança

* [ ] Bug fix
* [x] Nova funcionalidade
* [ ] Refatoração
* [x] Documentação
* [ ] Melhoria de performance
* [ ] Testes

## Issue relacionada


## Como testar

1. Verifique o arquivo `.github/workflows/metrics.yml`.
2. Após o merge na `main`, valide na aba **Actions** se o workflow é disparado automaticamente após um novo commit.

## Evidências (se aplicável)


## Impactos e riscos

Risco nulo. Apenas altera a frequência de execução da Action de métricas.

## Checklist

* [x] Código segue o padrão do projeto
* [ ] Testes adicionados/atualizados (se necessário)
* [x] Testado localmente
* [x] Documentação atualizada (se necessário)

## Observações adicionais

* O gatilho manual (`workflow_dispatch`) foi mantido para casos de necessidade pontual.