### PR TITLE
feat(RF05): implementa mapa interativo centralizado no DF (US 2.2.2)

### DIFF
--- a/.claude/skills/safestreets-implement-feature/SKILL.md
+++ b/.claude/skills/safestreets-implement-feature/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: safestreets-implement-feature
+description: Guia a implementação de uma feature do frontend SafeStreets seguindo Spec-Driven Development (spec.md/plan.md/tasks.md) e XP/TDD. Use quando solicitado a implementar uma feature, executar as tasks de uma spec, desenvolver um componente novo ou escrever os testes correspondentes.
+---
+
+# Implementação de Features (Spec-Driven + XP/TDD)
+
+Este skill guia a implementação de uma feature do frontend SafeStreets a partir dos
+documentos de uma pasta `frontend/Specs/Specs_<feature>/` (`constitution.md`,
+`spec.md`, `plan.md`, `tasks.md`), seguindo Extreme Programming: entregas pequenas,
+testes escritos junto com o código e refatoração contínua.
+
+## Antes de começar
+1. Leia `frontend/Specs/Specs_pg_inicial/constitution.md` — princípios não-negociáveis
+   do projeto (paleta de cores, CSS Modules, TypeScript, componentização, separação
+   de camadas, etc.). Toda implementação deve respeitar este documento.
+2. Leia `spec.md` da feature — entenda o problema, os requisitos (RF) cobertos, as
+   User Stories e, principalmente, os **critérios de aceitação**. Eles são a fonte
+   da verdade para os testes.
+3. Leia `plan.md` — estrutura de pastas, stack/dependências e decisões técnicas já
+   definidas. Não improvise uma abordagem diferente sem atualizar o `plan.md`.
+4. Leia `tasks.md` — lista ordenada de tarefas (T001, T002, ...) com dependências e
+   marcação `[P]` para tarefas paralelas.
+
+## Fluxo por tarefa (ciclo TDD: red → green → refactor)
+Para cada tarefa de `tasks.md`, na ordem (respeitando dependências):
+
+1. **Red** — escreva primeiro o(s) teste(s) do componente/função da tarefa em
+   `frontend/__tests__/<categoria>/<Nome>.test.tsx`, cobrindo pelo menos:
+   - um caso de fluxo esperado (happy path), derivado dos critérios de aceitação do
+     `spec.md`;
+   - um caso de borda/exceção (lista vazia, prop ausente, estado inicial, etc.).
+   Rode os testes e confirme que falham (o componente ainda não existe/está incompleto).
+
+2. **Green** — implemente o mínimo necessário em `components/`, `view/`, `app/`,
+   `utils/` (conforme `plan.md`) para os testes passarem. Siga as convenções do
+   projeto: TypeScript tipado, CSS Modules ao lado do componente, paleta
+   `#016d01` / `#f8c311` / `#ffffff`.
+
+3. **Refactor** — com os testes verdes, limpe duplicação, nomes e estrutura sem
+   alterar comportamento. Rode os testes de novo para garantir que continuam
+   passando.
+
+4. **Marque a tarefa como concluída** (`- [x]`) em `tasks.md`.
+
+5. **Commit** referenciando o requisito/tarefa, ex:
+   `feat(RF05): renderiza mapa interativo centralizado no DF (T002)`.
+
+## Executando os testes
+Use a skill `safestreets-run-frontend-tests` para comandos, configuração do Jest e
+armadilhas conhecidas (ex: mock de `next/navigation`, `next/image`, problemas com
+`jsdom`). Resumo rápido:
+```powershell
+cd frontend
+npx jest <caminho-do-teste>   # durante o desenvolvimento (TDD)
+npm test                       # antes de marcar a fase como concluída
+```
+
+## Ao concluir todas as tarefas de uma fase/feature
+- Confirme cada item da seção **"Critérios de pronto (Definition of Done)"** do
+  `tasks.md` contra o app rodando (`npm run dev`) e contra a suíte de testes
+  (`npm test`).
+- Revise os **critérios de aceitação** do `spec.md` um a um — cada `Dado/Quando/Então`
+  deve corresponder a um comportamento observável (manual ou via teste).
+- Só então considere a feature pronta para revisão/PR.
+
+## Regras gerais (reforço da constitution)
+- Nada de frameworks de CSS além de CSS Modules.
+- Sem `any` implícito em TypeScript.
+- Componentes pequenos, com responsabilidade única — nada de páginas monolíticas.
+- O frontend nunca acessa fontes de dados diretamente: passa por uma camada de
+  dados isolada (`utils/`/`data/`), hoje mockada.
+- Nenhuma chave de API ou credencial no código do frontend.

--- a/.claude/skills/safestreets-run-frontend-tests/SKILL.md
+++ b/.claude/skills/safestreets-run-frontend-tests/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: run-frontend-tests
+name: safestreets-run-frontend-tests
 description: Executa testes unitários do frontend do SafeStreets. Use quando solicitado a testar, rodar testes, verificar cobertura ou validar o comportamento de componentes na pasta frontend.
 ---
 

--- a/frontend/Specs/Specs_mapa_interativo/plan.md
+++ b/frontend/Specs/Specs_mapa_interativo/plan.md
@@ -1,0 +1,85 @@
+# Plano técnico — Feature 002: Mapa interativo
+
+> Blueprint técnico derivado de `spec.md`. Respeita `.2026-1-SafeStreets\frontend\Specs\Specs_pg_inicial\constitution.md`.
+> Referência visual: protótipo de alta fidelidade do SafeStreets (tela: Mapa de risco).
+
+## Stack
+- **Framework:** Next.js (App Router) — já configurado no projeto.
+- **Linguagem:** TypeScript + JSX.
+- **Mapa:** [Leaflet](https://leafletjs.com/) + [react-leaflet](https://react-leaflet.js.org/),
+  com tiles do **OpenStreetMap**.
+  - Justificativa: open-source, gratuito, sem necessidade de chave de API
+    (atende RNF07 — nenhuma credencial exposta no frontend).
+  - Componente do mapa precisa ser **Client Component** (`"use client"`) e carregado
+    via `next/dynamic` com `ssr: false`, pois Leaflet acessa `window`/`document`
+    e não pode ser renderizado no servidor.
+- **Estilização:** CSS Modules (`.module.css`), conforme constituição.
+
+## Estrutura de pastas (incrementos sobre a estrutura atual)
+```
+frontend/
+  app/
+    mapa/
+      page.tsx                    # inalterado: continua renderizando view/Mapa/Mapa.tsx
+  view/
+    Mapa/
+      Mapa.tsx                    # passa a renderizar <MapaInterativo /> em tela cheia
+      Mapa.module.css             # layout full-screen (sem Footer)
+  components/
+    Chrome/
+      Chrome.tsx                  # passa a aceitar variante "overlay" para a rota /mapa
+      Chrome.module.css           # estilos de overlay (Header/Drawer transparentes sobre o mapa)
+    MapaInterativo/
+      MapaInterativo.tsx          # "use client" — dynamic import do MapView (ssr: false)
+      MapaInterativo.module.css   # container full-screen
+      MapView.tsx                 # "use client" — MapContainer + TileLayer do react-leaflet
+  style/
+    globals.css                   # ajuste: permitir layout full-bleed na rota /mapa
+```
+
+## Comportamento do `Chrome` na rota `/mapa`
+- O `Chrome` detecta a rota atual (via `usePathname`).
+- Quando a rota é `/mapa`:
+  - `Footer` não é renderizado.
+  - `Header` e `Drawer` são renderizados em posição `absolute`/`fixed`, com fundo
+    transparente (ou translúcido leve), sobre o mapa — sem faixa de cor de fundo
+    separando-os da área do mapa.
+  - O conteúdo (`children`, isto é, `<Mapa />`) ocupa `100vw` x `100vh`.
+- Em outras rotas, o comportamento atual (`Header` opaco + `Footer`) é preservado.
+
+## Configuração do mapa (`MapView.tsx`)
+- `MapContainer`:
+  - `center`: `[-15.7797, -47.9297]` (centro aproximado do DF).
+  - `zoom`: `11` (zoom padrão que enquadra as Regiões Administrativas do DF).
+  - `zoomControl`: `false` (controle padrão desabilitado), `scrollWheelZoom`: `true`,
+    `dragging`: `true`.
+  - `style`: `{ width: "100%", height: "100%" }`.
+  - `<ZoomControl position="bottomleft" />`: controle de zoom reposicionado para o
+    canto inferior esquerdo, evitando sobreposição com o logo/botão de menu do
+    `Header` overlay (canto superior esquerdo).
+- `TileLayer`:
+  - `url`: `https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png`
+  - `attribution`: `&copy; OpenStreetMap contributors` (obrigatório pela licença ODbL).
+- **Sem marcadores** nesta feature (conforme `spec.md`) — o array de ocorrências
+  fica vazio/ausente; a camada de marcadores será adicionada em feature futura
+  (RF04/RF06).
+
+## Dependências novas
+Adicionar em `frontend/package.json`:
+- `leaflet`
+- `react-leaflet`
+- `@types/leaflet` (devDependency)
+
+## Estilo CSS do mapa
+- O CSS do Leaflet (`leaflet/dist/leaflet.css`) deve ser importado uma única vez,
+  em `MapaInterativo.tsx` ou em `style/globals.css`.
+- `MapaInterativo.module.css` e `Mapa.module.css` definem `width: 100vw; height: 100vh;`
+  (ou `100dvh`) para o container do mapa.
+
+## Testes
+- Seguir o padrão de `frontend/__tests__/components/`.
+- Como Leaflet depende do DOM/`window`, os testes do `MapaInterativo`/`MapView`
+  devem usar mocks (ex.: mockar `react-leaflet` com `jest.mock`) para verificar que
+  o componente renderiza o container do mapa sem erros em ambiente `jsdom`.
+- Teste do `Chrome`: verificar que, na rota `/mapa`, o `Footer` não é renderizado e
+  o `Header`/`Drawer` recebem a variante "overlay".

--- a/frontend/Specs/Specs_mapa_interativo/spec.md
+++ b/frontend/Specs/Specs_mapa_interativo/spec.md
@@ -1,0 +1,61 @@
+# Spec — Feature 002: Mapa interativo
+
+> O **quê** e o **porquê**. Sem detalhes de implementação (isso vai no PLAN).
+> Referência obrigatória: `.2026-1-SafeStreets\frontend\Specs\Specs_pg_inicial\constitution.md`
+> Referência visual: protótipo de alta fidelidade do SafeStreets (tela: Mapa de risco).
+
+## Problema
+A rota `/mapa` hoje exibe apenas um placeholder estático ("Em breve"). O cidadão
+precisa visualizar geograficamente o mapa do DF assim que acessa essa seção, sem
+precisar de nenhuma ação adicional, para começar a explorar as áreas imediatamente.
+
+## Objetivos desta entrega
+- [x] Substituir o placeholder da rota `/mapa` por um mapa interativo real.
+- [x] Carregar o mapa automaticamente ao acessar a página, centralizado no Distrito
+      Federal com zoom padrão.
+- [x] Permitir que o usuário explore o mapa livremente (arrastar/pan e zoom in/out).
+
+## Requisitos cobertos
+- **RF05 — Renderização do Mapa:** o sistema deve apresentar um mapa interativo
+  integrado à interface principal. O mapa pode ser explorado e será carregado com
+  zoom padrão centralizado no DF.
+
+## User Stories
+- **US 2.2.2** — Como cidadão, quero que o mapa interativo carregue ao acessar o
+  sistema, já exibindo regiões do DF, para que eu possa começar a explorar as áreas
+  imediatamente.
+
+## Layout de referência (protótipo)
+- Ao selecionar "Mapa" no menu, a rota `/mapa` exibe o mapa interativo **ocupando a
+  tela inteira** (viewport completa), sem o `Footer` e sem áreas de conteúdo
+  separadas por bordas/cards.
+- A barra superior (`Header`) e o `Drawer` continuam disponíveis, porém **integrados
+  visualmente ao mapa**: ficam sobrepostos (overlay) sobre o mapa, sem uma divisória
+  ou faixa de fundo separando-os da área do mapa — o mapa preenche todo o espaço
+  por trás/sob esses elementos.
+
+## Critérios de aceitação
+
+### RF05 — Renderização do mapa (US 2.2.2)
+- **Dado** que o usuário acessa a rota `/mapa`, **quando** a página carrega,
+  **então** o mapa interativo deve ser renderizado automaticamente, ocupando toda a
+  tela, sem necessidade de nenhuma ação adicional do usuário.
+- **Dado** que o mapa foi renderizado, **então** ele deve ser exibido com zoom
+  padrão centralizado na região do Distrito Federal (lat/long aproximados:
+  `-15.7797, -47.9297`).
+- **Dado** que o mapa está carregado, **quando** o usuário arrasta o mapa ou usa os
+  controles de zoom, **então** ele deve conseguir explorar livremente (pan e
+  zoom in/out) as regiões exibidas, inclusive nas áreas cobertas pelo `Header`/`Drawer`.
+- **Dado** que o usuário acessa o mapa diretamente pelo menu (sem ter feito nenhuma
+  busca no dashboard de pesquisa), **então** o mapa deve carregar **sem
+  marcadores/pins** — nenhuma ocorrência é exibida por padrão.
+
+## Fora de escopo (NÃO fazer agora)
+- Exibição de marcadores (pins) de ocorrências — estes só aparecem após uma busca no
+  dashboard de pesquisa (RF06, Épico 3) e ao linkar uma notícia selecionada (RF04 —
+  US 2.2.1), ambos em features futuras.
+- Card resumo ao selecionar marcador/notícia (RF04 — US 2.2.1, próxima feature).
+- Filtros por região administrativa e período (RF06+).
+- Mensagem "Nenhum resultado encontrado" e limpeza de filtros (RF07, RF08).
+- Resumo gerado por IA (RF11).
+- Responsividade mobile.

--- a/frontend/Specs/Specs_mapa_interativo/tasks.md
+++ b/frontend/Specs/Specs_mapa_interativo/tasks.md
@@ -1,0 +1,44 @@
+# Tasks — Feature 002: Mapa interativo
+
+> Referências: `spec.md`, `plan.md`, `.2026-1-SafeStreets\frontend\Specs\Specs_pg_inicial\constitution.md`
+> `[P]` = pode rodar em paralelo (não depende de outra tarefa em andamento).
+> Antes de cada mudança, o agente revisita spec.md e plan.md.
+
+## Fase 0 — Setup
+- [x] T001 Adicionar dependências `leaflet`, `react-leaflet` e `@types/leaflet` —
+  `frontend/package.json`
+
+## Fase 1 — Mapa interativo (RF05)
+- [x] T002 Componente `MapView` (`"use client"`): `MapContainer` + `TileLayer`
+  (OpenStreetMap), centralizado no DF (`[-15.7797, -47.9297]`), `zoom: 11`, sem
+  marcadores — `components/MapaInterativo/MapView.tsx` (depende: T001)
+- [x] T003 Componente `MapaInterativo` (`"use client"`): `next/dynamic` (`ssr: false`)
+  para `MapView`, container full-screen — `components/MapaInterativo/MapaInterativo.tsx`
+  (+ `.module.css`) (depende: T002)
+
+## Fase 2 — Layout full-screen e overlay do Chrome
+- [x] T004 Atualizar `view/Mapa/Mapa.tsx` para renderizar `<MapaInterativo />` em
+  tela cheia, removendo o conteúdo placeholder — `view/Mapa/Mapa.tsx` (+ `.module.css`)
+  (depende: T003)
+- [x] T005 Atualizar `Chrome` para detectar a rota `/mapa` (`usePathname`) e aplicar
+  variante "overlay": oculta `Footer`, posiciona `Header`/`Drawer` sobrepostos ao
+  mapa sem faixa de fundo separando-os — `components/Chrome/Chrome.tsx`
+  (+ `.module.css`) (depende: T004)
+
+## Fase 3 — Testes
+- [x] T006 [P] Teste do `MapaInterativo`/`MapView` com mock de `react-leaflet`,
+  garantindo renderização sem erro em `jsdom` — `__tests__/components/MapaInterativo.test.tsx`
+  (depende: T003)
+- [x] T007 [P] Teste do `Chrome` cobrindo a variante overlay na rota `/mapa`
+  (sem `Footer`, `Header`/`Drawer` sobrepostos) — `__tests__/components/Chrome.test.tsx`
+  (depende: T005)
+
+## Critérios de pronto (Definition of Done)
+- A rota `/mapa` renderiza um mapa interativo real (Leaflet/OpenStreetMap),
+  ocupando 100% da viewport, sem necessidade de ação do usuário.
+- O mapa carrega centralizado no DF (`-15.7797, -47.9297`) com zoom padrão (`11`).
+- O usuário consegue arrastar (pan) e dar zoom in/out livremente.
+- Nenhum marcador/pin é exibido por padrão ao acessar `/mapa` pelo menu.
+- `Header` e `Drawer` aparecem sobrepostos ao mapa, sem faixa de fundo separando-os;
+  o `Footer` não é exibido na rota `/mapa`.
+- Testes novos/atualizados passam (`npm test`).

--- a/frontend/__tests__/components/Chrome.test.tsx
+++ b/frontend/__tests__/components/Chrome.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { usePathname } from "next/navigation";
 import Chrome from "@/components/Chrome/Chrome";
 
 jest.mock("next/navigation", () => ({
@@ -73,6 +74,33 @@ describe("Chrome", () => {
         fireEvent.click(menuBtn);
         fireEvent.click(screen.getByRole("button", { name: /Fechar menu/i }));
       }).not.toThrow();
+    });
+  });
+
+  describe("overlay layout on /mapa (RF05)", () => {
+    beforeEach(() => {
+      (usePathname as jest.Mock).mockReturnValue("/mapa");
+    });
+
+    afterEach(() => {
+      (usePathname as jest.Mock).mockReturnValue("/");
+    });
+
+    it("does not render the Footer", () => {
+      render(<Chrome><span /></Chrome>);
+      expect(screen.queryByRole("contentinfo")).not.toBeInTheDocument();
+    });
+
+    it("renders the Header overlaying the content, without background separation", () => {
+      render(<Chrome><span /></Chrome>);
+      const header = screen.getByRole("banner");
+      expect(header.className).toMatch(/headerOverlay/);
+    });
+
+    it("renders children in a full-screen main element", () => {
+      render(<Chrome><span /></Chrome>);
+      const main = screen.getByRole("main");
+      expect(main.className).toMatch(/mainFullScreen/);
     });
   });
 

--- a/frontend/__tests__/components/Header.test.tsx
+++ b/frontend/__tests__/components/Header.test.tsx
@@ -31,6 +31,19 @@ describe("Header", () => {
     });
   });
 
+  describe("overlay variant (rota /mapa)", () => {
+    it("does not render the search box", () => {
+      render(<Header onMenuClick={jest.fn()} overlay />);
+      expect(screen.queryByText(/Buscar por região/i)).not.toBeInTheDocument();
+    });
+
+    it("still renders the menu button and logo", () => {
+      render(<Header onMenuClick={jest.fn()} overlay />);
+      expect(screen.getByRole("button", { name: /Abrir menu/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /SafeStreets/i })).toBeInTheDocument();
+    });
+  });
+
   describe("interactions", () => {
     it("calls onMenuClick when the menu button is clicked", () => {
       const onMenuClick = jest.fn();

--- a/frontend/__tests__/components/MapaInterativo.test.tsx
+++ b/frontend/__tests__/components/MapaInterativo.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import MapaInterativo from "@/components/MapaInterativo/MapaInterativo";
+
+jest.mock("next/dynamic", () => () => {
+  const MapView = require("@/components/MapaInterativo/MapView").default;
+  return MapView;
+});
+
+jest.mock("react-leaflet", () => ({
+  MapContainer: ({
+    children,
+    center,
+    zoom,
+  }: {
+    children: React.ReactNode;
+    center: [number, number];
+    zoom: number;
+  }) => (
+    <div
+      data-testid="map-container"
+      data-center={JSON.stringify(center)}
+      data-zoom={zoom}
+    >
+      {children}
+    </div>
+  ),
+  TileLayer: ({ url, attribution }: { url: string; attribution: string }) => (
+    <div data-testid="tile-layer" data-url={url} data-attribution={attribution} />
+  ),
+  ZoomControl: ({ position }: { position: string }) => (
+    <div data-testid="zoom-control" data-position={position} />
+  ),
+}));
+
+describe("MapaInterativo", () => {
+  it("renders the map container centered on the DF with the default zoom", () => {
+    render(<MapaInterativo />);
+    const map = screen.getByTestId("map-container");
+    expect(map).toBeInTheDocument();
+    expect(JSON.parse(map.getAttribute("data-center")!)).toEqual([-15.7797, -47.9297]);
+    expect(map.getAttribute("data-zoom")).toBe("11");
+  });
+
+  it("renders the OpenStreetMap tile layer with attribution", () => {
+    render(<MapaInterativo />);
+    const tileLayer = screen.getByTestId("tile-layer");
+    expect(tileLayer.getAttribute("data-url")).toContain("tile.openstreetmap.org");
+    expect(tileLayer.getAttribute("data-attribution")).toMatch(/OpenStreetMap/i);
+  });
+
+  it("renders without any markers by default (edge: no ocorrências yet)", () => {
+    render(<MapaInterativo />);
+    expect(screen.queryByTestId("marker")).not.toBeInTheDocument();
+  });
+
+  it("positions the zoom control at the bottom-left, away from the logo/menu", () => {
+    render(<MapaInterativo />);
+    expect(screen.getByTestId("zoom-control").getAttribute("data-position")).toBe(
+      "bottomleft"
+    );
+  });
+});

--- a/frontend/components/Chrome/Chrome.module.css
+++ b/frontend/components/Chrome/Chrome.module.css
@@ -1,3 +1,10 @@
 .main {
   min-height: calc(100vh - 60px);
 }
+
+.mainFullScreen {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+}

--- a/frontend/components/Chrome/Chrome.tsx
+++ b/frontend/components/Chrome/Chrome.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { usePathname } from "next/navigation";
 import Header from "@/components/Header/Header";
 import Drawer from "@/components/Drawer/Drawer";
 import Footer from "@/components/Footer/Footer";
@@ -12,13 +13,17 @@ interface ChromeProps {
 
 export default function Chrome({ children }: ChromeProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const pathname = usePathname();
+  const isMapRoute = pathname === "/mapa";
 
   return (
     <>
-      <Header onMenuClick={() => setDrawerOpen(true)} />
+      <Header onMenuClick={() => setDrawerOpen(true)} overlay={isMapRoute} />
       <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
-      <main className={styles.main}>{children}</main>
-      <Footer />
+      <main className={isMapRoute ? styles.mainFullScreen : styles.main}>
+        {children}
+      </main>
+      {!isMapRoute && <Footer />}
     </>
   );
 }

--- a/frontend/components/Header/Header.module.css
+++ b/frontend/components/Header/Header.module.css
@@ -11,6 +11,13 @@
   border-bottom: 1px solid var(--cor-linha);
 }
 
+.headerOverlay {
+  position: fixed;
+  width: 100%;
+  background-color: transparent;
+  border-bottom: none;
+}
+
 .left {
   display: flex;
   align-items: center;

--- a/frontend/components/Header/Header.tsx
+++ b/frontend/components/Header/Header.tsx
@@ -5,11 +5,14 @@ import styles from "./Header.module.css";
 
 interface HeaderProps {
   onMenuClick: () => void;
+  overlay?: boolean;
 }
 
-export default function Header({ onMenuClick }: HeaderProps) {
+export default function Header({ onMenuClick, overlay = false }: HeaderProps) {
   return (
-    <header className={styles.header}>
+    <header
+      className={overlay ? `${styles.header} ${styles.headerOverlay}` : styles.header}
+    >
       <div className={styles.left}>
         <button
           className={styles.menuButton}
@@ -23,12 +26,14 @@ export default function Header({ onMenuClick }: HeaderProps) {
         </Link>
       </div>
 
-      <div className={styles.right}>
-        <div className={styles.searchBox} aria-label="Campo de busca (visual)">
-          <SearchIcon size={16} color="var(--cor-cinza)" />
-          <span className={styles.searchPlaceholder}>Buscar por região ou crim...</span>
+      {!overlay && (
+        <div className={styles.right}>
+          <div className={styles.searchBox} aria-label="Campo de busca (visual)">
+            <SearchIcon size={16} color="var(--cor-cinza)" />
+            <span className={styles.searchPlaceholder}>Buscar por região ou crim...</span>
+          </div>
         </div>
-      </div>
+      )}
     </header>
   );
 }

--- a/frontend/components/MapaInterativo/MapView.tsx
+++ b/frontend/components/MapaInterativo/MapView.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { MapContainer, TileLayer, ZoomControl } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+
+export const DF_CENTER: [number, number] = [-15.7797, -47.9297];
+export const DF_DEFAULT_ZOOM = 11;
+
+export default function MapView() {
+  return (
+    <MapContainer
+      center={DF_CENTER}
+      zoom={DF_DEFAULT_ZOOM}
+      scrollWheelZoom
+      zoomControl={false}
+      style={{ width: "100%", height: "100%" }}
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <ZoomControl position="bottomleft" />
+    </MapContainer>
+  );
+}

--- a/frontend/components/MapaInterativo/MapaInterativo.module.css
+++ b/frontend/components/MapaInterativo/MapaInterativo.module.css
@@ -1,4 +1,4 @@
-.page {
+.container {
   width: 100%;
   height: 100%;
 }

--- a/frontend/components/MapaInterativo/MapaInterativo.tsx
+++ b/frontend/components/MapaInterativo/MapaInterativo.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import styles from "./MapaInterativo.module.css";
+
+const MapView = dynamic(() => import("./MapView"), {
+  ssr: false,
+});
+
+export default function MapaInterativo() {
+  return (
+    <div className={styles.container}>
+      <MapView />
+    </div>
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,15 +8,18 @@
       "name": "safestreets-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "leaflet": "^1.9.4",
         "next": "15.5.19",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-leaflet": "^5.0.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^30.0.0",
+        "@types/leaflet": "^1.9.21",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1974,6 +1977,17 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
@@ -2164,6 +2178,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2241,6 +2262,16 @@
         "@types/node": "*",
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/node": {
@@ -4825,6 +4856,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5447,6 +5484,20 @@
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,15 +11,18 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
     "next": "15.5.19",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-leaflet": "^5.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
+    "@types/leaflet": "^1.9.21",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/frontend/view/Mapa/Mapa.tsx
+++ b/frontend/view/Mapa/Mapa.tsx
@@ -1,13 +1,10 @@
+import MapaInterativo from "@/components/MapaInterativo/MapaInterativo";
 import styles from "./Mapa.module.css";
 
 export default function Mapa() {
   return (
     <div className={styles.page}>
-      <p className={styles.label}>MAPA DE RISCO</p>
-      <h1 className={styles.title}>Em breve</h1>
-      <p className={styles.description}>
-        O mapa interativo de risco por Região Administrativa está em desenvolvimento.
-      </p>
+      <MapaInterativo />
     </div>
   );
 }


### PR DESCRIPTION
## Descrição

Implementa o mapa interativo (RF05 / US 2.2.2): ao acessar `/mapa`, o usuário vê um mapa em tela cheia, centralizado no Distrito Federal, totalmente explorável (zoom e arraste). O cabeçalho e o menu ficam sobrepostos ao mapa, sem faixa de separação, e o rodapé é ocultado nessa rota. Por enquanto, nenhuma ocorrência é exibida no mapa — marcadores serão adicionados em uma feature futura, após a pesquisa no dashboard.

A implementação foi feita seguindo TDD: testes escritos primeiro (red), depois o código necessário para passá-los (green), com refatoração ao final.

## Tipo de mudança

- [x] Nova funcionalidade
- [x] Testes

## Issue relacionada

RF05 / US 2.2.2 — Mapa interativo (`frontend/Specs/Specs_mapa_interativo/spec.md`)

## Como testar

1. `git checkout feat/frontend-mapa-interativo`
2. `cd frontend`
3. `npm install`
4. `npm run dev`
5. Acesse `http://localhost:3000/mapa`
6. Verifique:
   - O mapa ocupa a tela inteira, centralizado no DF
   - É possível arrastar e dar zoom (controles de zoom no canto inferior esquerdo)
   - O cabeçalho/logo/menu aparecem sobrepostos ao mapa, sem barra de pesquisa
   - O rodapé não aparece nessa rota
   - Nenhum marcador é exibido no mapa

Para rodar os testes automatizados:
```powershell
npm test
```

## Evidências

- Print do mapa renderizado em `/mapa` (enviado anteriormente no chat)

## Impactos e riscos

- Novas dependências adicionadas: `leaflet`, `react-leaflet`, `@types/leaflet`
- O componente `Header` recebeu uma prop `overlay` opcional; o comportamento padrão (outras rotas) não é afetado
- O `Chrome` agora detecta a rota atual para decidir o layout (overlay apenas em `/mapa`)
- Sem impacto em backend, autenticação ou dados sensíveis (tiles do OpenStreetMap, sem chave de API)

## Checklist

- [x] Código segue os padrões do projeto (TypeScript, CSS Modules)
- [x] Testes novos/atualizados cobrindo o comportamento implementado
- [x] `npm test` passa localmente
- [x] Documentação da spec (`spec.md`/`plan.md`/`tasks.md`) atualizada

## Observações adicionais

Esta é a primeira etapa do mapeamento de ocorrências (Épico 2). A exibição de marcadores/ocorrências será feita em uma feature futura, após a pesquisa no dashboard (RF04/RF06).
