### PR TITLE
Atualização do dashboard de busca 

### DIFF
--- a/frontend/Specs/Specs_dashboard_busca/plan.md
+++ b/frontend/Specs/Specs_dashboard_busca/plan.md
@@ -1,0 +1,106 @@
+# Plano técnico — Feature 003: Dashboard de Busca — Painel de Filtros
+
+> Blueprint técnico derivado de `spec.md`. Respeita `.2026-1-SafeStreets\frontend\Specs\Specs_pg_inicial\constitution.md`.
+> Referência visual: protótipo de alta fidelidade do SafeStreets (painel "FILTROS"
+> sobreposto ao mapa).
+
+## Stack
+- **Framework:** Next.js (App Router) — já configurado.
+- **Linguagem:** TypeScript + JSX.
+- **Estilização:** CSS Modules (`.module.css`), conforme constituição. Sem
+  dependências novas.
+- **Estado:** `useState` local no componente `PainelFiltros` (sem necessidade de
+  estado global nesta entrega).
+
+## Estrutura de pastas (incrementos sobre a estrutura atual)
+```
+frontend/
+  utils/
+    noticias.ts                 # inalterado
+    filtros.ts                  # novo: REGIOES_ADMINISTRATIVAS, PERIODOS
+  components/
+    icons/
+      index.tsx                 # + ChevronDownIcon
+    PainelFiltros/
+      PainelFiltros.tsx         # "use client" — painel de filtros
+      PainelFiltros.module.css
+  view/
+    Mapa/
+      Mapa.tsx                  # + <PainelFiltros /> como overlay
+      Mapa.module.css           # position: relative no container
+```
+
+## Camada de dados (`utils/filtros.ts`)
+- `REGIOES_ADMINISTRATIVAS: string[]`: lista derivada de
+  `noticias.map(n => n.regiao)`, sem duplicatas, ordenada alfabeticamente. Mantém
+  o princípio de separação de camadas (frontend não acessa fonte de dados
+  diretamente — hoje mock, futuramente API).
+- `PERIODOS: { value: string; label: string }[]`: opções estáticas mockadas:
+  - `{ value: "7d", label: "Últimos 7 dias" }`
+  - `{ value: "30d", label: "Últimos 30 dias" }`
+  - `{ value: "3m", label: "Últimos 3 meses" }`
+  - `{ value: "1y", label: "Último ano" }`
+
+## Componente `PainelFiltros`
+- **Props:** nenhuma nesta entrega (estado totalmente local/interno).
+- **Estado interno (`useState`):**
+  - `regiao: string` (default `""`)
+  - `periodo: string` (default `""`)
+  - `busca: string` (default `""`)
+  - `expandido: boolean` (default `true`)
+- **Estrutura JSX:**
+  - `<section>` raiz com `aria-label="Filtros de busca"`.
+  - Cabeçalho: `<h2>FILTROS</h2>` + `<button>` com `ChevronDownIcon`
+    (`aria-label="Recolher filtros"` / `"Expandir filtros"` conforme estado),
+    que alterna `expandido`.
+  - Corpo (renderizado apenas quando `expandido === true`):
+    - `<label>` + `<select>` "Região Administrativa", `value={regiao}`,
+      `onChange` atualiza estado. Primeira `<option value="">Escolha uma
+      opção</option>`, seguida das opções de `REGIOES_ADMINISTRATIVAS`.
+    - `<label>` + `<select>` "Período", mesmo padrão, opções de `PERIODOS`.
+    - `<hr>`/divisória.
+    - `<button>` "Limpar filtros": `onClick` reseta `regiao`, `periodo` e
+      `busca` para os valores default.
+    - `<div>` com `<input type="text" placeholder="Buscar">` controlado por
+      `busca` + `SearchIcon` (de `components/icons`).
+- **Sem chamadas de API** — apenas consome `REGIOES_ADMINISTRATIVAS` e
+  `PERIODOS` de `utils/filtros.ts`.
+
+## Ícone novo (`components/icons/index.tsx`)
+- `ChevronDownIcon`: segue o mesmo padrão dos ícones existentes (`size`,
+  `color`, `className`, `viewBox="0 0 24 24"`), path em formato de seta para
+  baixo (`M6 9l6 6 6-6`).
+
+## Integração com `/mapa`
+- `view/Mapa/Mapa.tsx`: importa e renderiza `<PainelFiltros />` dentro do mesmo
+  container (`styles.page`) que já contém `<MapaInterativo />`.
+- `view/Mapa/Mapa.module.css`: adiciona `position: relative` ao `.page` (o mapa
+  e o `MapaInterativo` continuam `width: 100%; height: 100%`, sem alteração de
+  comportamento).
+- `PainelFiltros.module.css`: o `<section>` raiz usa
+  `position: absolute; top: 84px; right: 24px; z-index: 500;` (abaixo do
+  `Header`/`Drawer`, que têm z-index maior, e acima do mapa Leaflet, cujos
+  paines ficam em z-index < 500).
+
+## Estilo visual (paleta da constitution)
+- Card: fundo `#ffffff`, `border-radius` ~16px, `box-shadow` leve, padding
+  interno consistente com o protótipo.
+- Título "FILTROS": cor `#016d01` (verde principal), peso bold.
+- Botão de recolher/expandir: círculo de fundo `#f8c311` (amarelo), ícone
+  `ChevronDownIcon` em verde/branco.
+- Selects: borda cinza clara, texto cinza, placeholder "Escolha uma opção".
+- Botão "Limpar filtros": estilo outline (borda verde, texto verde, fundo
+  transparente/branco).
+- Campo "Buscar": fundo cinza claro, `border-radius` arredondado, ícone
+  `SearchIcon` (`var(--cor-cinza)`).
+
+## Testes
+- Seguir o padrão de `frontend/__tests__/components/` e `__tests__/utils/`.
+- `__tests__/utils/filtros.test.ts`: valida conteúdo/forma de
+  `REGIOES_ADMINISTRATIVAS` e `PERIODOS`.
+- `__tests__/components/PainelFiltros.test.tsx`: renderiza sem mocks externos
+  (componente é puro React + CSS Modules, sem Leaflet/`next/dynamic`).
+  Cobre: renderização inicial, seleção de região/período, digitação na busca,
+  "Limpar filtros" e toggle de recolher/expandir.
+- `__tests__/components/icons.test.tsx`: adiciona caso de snapshot/render para
+  `ChevronDownIcon`, seguindo o padrão dos demais ícones já testados.

--- a/frontend/Specs/Specs_dashboard_busca/spec.md
+++ b/frontend/Specs/Specs_dashboard_busca/spec.md
@@ -1,0 +1,99 @@
+# Spec — Feature 003: Dashboard de Busca — Painel de Filtros
+
+> O **quê** e o **porquê**. Sem detalhes de implementação (isso vai no PLAN).
+> Referência obrigatória: `.2026-1-SafeStreets\frontend\Specs\Specs_pg_inicial\constitution.md`
+> Referência visual: protótipo de alta fidelidade do SafeStreets (tela: Mapa de
+> risco com painel "FILTROS" sobreposto).
+
+## Problema
+A rota `/mapa` hoje exibe apenas o mapa interativo, sem nenhuma forma de o
+cidadão refinar o que está vendo. O Épico 3 (Dashboard de Busca/Filtros) prevê
+um menu lateral de filtros por Região Administrativa e Período, com opção de
+"Limpar filtros" — ainda ausente na interface.
+
+## Objetivos desta entrega
+- [x] Adicionar, na rota `/mapa`, um painel "FILTROS" sobreposto ao mapa (canto
+      superior direito), seguindo o protótipo de alta fidelidade.
+- [x] Disponibilizar um seletor de "Região Administrativa" com opção placeholder
+      "Escolha uma opção" e a lista de RAs conhecidas.
+- [x] Disponibilizar um seletor de "Período" com opção placeholder
+      "Escolha uma opção" e opções de intervalo de tempo.
+- [x] Disponibilizar um campo "Buscar" com ícone de lupa.
+- [x] Disponibilizar o botão "Limpar filtros", que reseta os dois seletores e o
+      campo de busca para o estado inicial.
+
+## Requisitos cobertos
+- **RF06 — Filtro de Ocorrências (parcial — UI):** o sistema deve disponibilizar
+  um menu lateral de filtros que permita ao usuário refinar os pontos exibidos
+  no mapa por Região Administrativa e Período/Data. Nesta entrega os campos de
+  filtro existem e são funcionais como controles de UI (estado local); a
+  aplicação do filtro sobre marcadores reais é tratada em entrega futura, pois
+  o mapa ainda não exibe marcadores/ocorrências (ver `Specs_mapa_interativo`).
+- **RF08 — Limpeza de Filtros:** o sistema deve fornecer uma opção "Limpar
+  filtros" que remove os filtros aplicados (região, período e busca).
+
+## User Stories
+- **US 3.3.1 (parcial)** — Como cidadão, quero buscar notícias de monitoramento
+  urbano por região administrativa (RA) e ter a opção de filtrar por intervalos
+  de tempo. *(Esta entrega cobre os campos/seletores; a aplicação efetiva do
+  filtro aos resultados é entrega futura.)*
+- **US 3.3.3** — Como cidadão, quero que tenha uma opção de limpar filtros.
+
+## Layout de referência (protótipo)
+- Na rota `/mapa`, sobreposto ao mapa, no canto superior direito, aparece um
+  card branco com cantos arredondados e título "FILTROS" (em destaque, com um
+  botão circular amarelo de recolher/expandir ao lado).
+- Abaixo do título: campo "Região Administrativa" (label + seletor com texto
+  "Escolha uma opção" e seta indicadora) e campo "Período" (mesmo padrão).
+- Uma linha divisória separa os filtros dos controles inferiores.
+- Botão "Limpar filtros" em largura total, estilo neutro/outline.
+- Campo "Buscar" em largura total, fundo levemente acinzentado, com ícone de
+  lupa à direita.
+- O painel fica posicionado abaixo do `Header` overlay, sem cobrir o
+  menu/logo, e não ocupa a tela inteira — apenas a área de filtros no canto
+  superior direito do mapa.
+
+## Critérios de aceitação
+
+### RF06 — Campos de filtro (US 3.3.1, parcial)
+- **Dado** que o usuário acessa a rota `/mapa`, **então** o painel "FILTROS"
+  deve estar visível, sobreposto ao mapa, sem necessidade de nenhuma ação
+  adicional.
+- **Dado** que o painel "FILTROS" está visível, **então** deve haver um campo
+  "Região Administrativa" com um seletor cujo valor inicial é "Escolha uma
+  opção" e que lista as Regiões Administrativas conhecidas (Ex: Ceilândia,
+  Taguatinga).
+- **Dado** que o painel "FILTROS" está visível, **então** deve haver um campo
+  "Período" com um seletor cujo valor inicial é "Escolha uma opção" e que lista
+  opções de intervalo de tempo.
+- **Dado** que o usuário seleciona uma Região Administrativa e/ou um Período,
+  **então** o seletor correspondente deve refletir o valor escolhido.
+- **Dado** que o painel "FILTROS" está visível, **então** deve haver um campo
+  "Buscar" com ícone de lupa, no qual o usuário pode digitar texto livre.
+
+### RF08 — Limpar filtros (US 3.3.3)
+- **Dado** que o usuário possui Região Administrativa, Período e/ou texto de
+  busca preenchidos, **então** deve haver um botão "Limpar filtros" visível no
+  painel.
+- **Dado** que o usuário clica em "Limpar filtros", **então** o seletor de
+  Região Administrativa, o seletor de Período e o campo "Buscar" devem voltar
+  ao estado inicial ("Escolha uma opção" / vazio).
+
+### Recolher/expandir painel (aderência ao protótipo — RNF05)
+- **Dado** que o painel "FILTROS" está expandido (estado inicial), **quando** o
+  usuário clica no botão circular ao lado do título, **então** o corpo do
+  painel (campos de filtro, "Limpar filtros" e "Buscar") deve ser ocultado,
+  mantendo apenas o cabeçalho "FILTROS" visível.
+- **Dado** que o painel está recolhido, **quando** o usuário clica novamente no
+  botão, **então** o corpo do painel volta a ser exibido.
+
+## Fora de escopo (NÃO fazer agora)
+- Aplicação real dos filtros sobre marcadores/ocorrências no mapa (não há
+  marcadores ainda) e sobre uma lista de notícias do dashboard (RF06 completo).
+- Mensagem "Nenhum resultado encontrado" (RF07).
+- Combinação/interseção de filtros e atualização automática do dashboard
+  (US 3.3.1 completa, US 3.3.4).
+- Painel de produtividade com gráficos (RF09).
+- Card resumo de ocorrência / "Ver detalhes" (RF10, US 3.3.5, US 3.3.6).
+- Resumo gerado por IA (RF11).
+- Responsividade mobile.

--- a/frontend/Specs/Specs_dashboard_busca/tasks.md
+++ b/frontend/Specs/Specs_dashboard_busca/tasks.md
@@ -1,0 +1,50 @@
+# Tasks — Feature 003: Dashboard de Busca — Painel de Filtros
+
+> Referências: `spec.md`, `plan.md`, `.2026-1-SafeStreets\frontend\Specs\Specs_pg_inicial\constitution.md`
+> `[P]` = pode rodar em paralelo (não depende de outra tarefa em andamento).
+> Antes de cada mudança, o agente revisita spec.md e plan.md.
+
+## Fase 0 — Camada de dados
+- [x] T001 [P] Criar `utils/filtros.ts` com `REGIOES_ADMINISTRATIVAS` (derivado
+  de `utils/noticias.ts`, sem duplicatas, ordenado) e `PERIODOS` (opções
+  estáticas) — `frontend/utils/filtros.ts`
+- [x] T002 [P] Teste de `utils/filtros.ts`: `REGIOES_ADMINISTRATIVAS` contém
+  regiões conhecidas sem duplicatas; `PERIODOS` não vazio, com `value`/`label`
+  — `frontend/__tests__/utils/filtros.test.ts` (depende: T001)
+
+## Fase 1 — Ícone novo
+- [x] T003 [P] Adicionar `ChevronDownIcon` em `components/icons/index.tsx`,
+  seguindo o padrão dos ícones existentes — `frontend/components/icons/index.tsx`
+- [x] T004 [P] Teste de `ChevronDownIcon` em `__tests__/components/icons.test.tsx`
+  (depende: T003)
+
+## Fase 2 — Componente `PainelFiltros` (RF06 + RF08)
+- [x] T005 Teste do componente `PainelFiltros` cobrindo: renderização do
+  título "FILTROS", labels "Região Administrativa"/"Período" com placeholder
+  "Escolha uma opção", botão "Limpar filtros" e campo "Buscar"; seleção de
+  região/período; digitação na busca; "Limpar filtros" reseta tudo; toggle de
+  recolher/expandir — `frontend/__tests__/components/PainelFiltros.test.tsx`
+  (depende: T001, T003) — escrever ANTES da implementação (red)
+- [x] T006 Implementar `PainelFiltros.tsx` (`"use client"`, estado local:
+  `regiao`, `periodo`, `busca`, `expandido`) + `PainelFiltros.module.css`
+  (paleta `#016d01`/`#f8c311`/`#ffffff`, layout conforme protótipo) —
+  `frontend/components/PainelFiltros/PainelFiltros.tsx` (+ `.module.css`)
+  (depende: T005)
+
+## Fase 3 — Integração na rota `/mapa`
+- [x] T007 Atualizar `view/Mapa/Mapa.tsx` para renderizar `<PainelFiltros />`
+  como overlay sobre `<MapaInterativo />`; ajustar `Mapa.module.css`
+  (`position: relative`) — `frontend/view/Mapa/Mapa.tsx` (+ `.module.css`)
+  (depende: T006)
+
+## Critérios de pronto (Definition of Done)
+- A rota `/mapa` exibe o painel "FILTROS" sobreposto ao mapa, no canto superior
+  direito, sem ação adicional do usuário.
+- O painel tem seletor "Região Administrativa" (placeholder "Escolha uma
+  opção" + opções de RAs conhecidas) e seletor "Período" (placeholder
+  "Escolha uma opção" + opções de intervalo de tempo).
+- O painel tem campo "Buscar" com ícone de lupa e botão "Limpar filtros".
+- "Limpar filtros" reseta região, período e busca ao estado inicial.
+- O botão circular do cabeçalho recolhe/expande o corpo do painel.
+- Nenhuma lógica de filtragem de marcadores/notícias é exigida nesta entrega.
+- Testes novos/atualizados passam (`npm test`).

--- a/frontend/__tests__/components/PainelFiltros.test.tsx
+++ b/frontend/__tests__/components/PainelFiltros.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import PainelFiltros from "@/components/PainelFiltros/PainelFiltros";
+import { REGIOES_ADMINISTRATIVAS, PERIODOS } from "@/utils/filtros";
+
+describe("PainelFiltros", () => {
+  describe("rendering", () => {
+    it("renders the 'FILTROS' title", () => {
+      render(<PainelFiltros />);
+      expect(screen.getByText("FILTROS")).toBeInTheDocument();
+    });
+
+    it("renders the 'Região Administrativa' select with placeholder and known regions", () => {
+      render(<PainelFiltros />);
+      const select = screen.getByLabelText("Região Administrativa");
+      expect(select).toBeInTheDocument();
+      expect((select as HTMLSelectElement).value).toBe("");
+      expect(screen.getByText("Escolha uma opção", { selector: "select[aria-label='Região Administrativa'] option" })).toBeInTheDocument();
+      REGIOES_ADMINISTRATIVAS.forEach((regiao) => {
+        expect(screen.getByRole("option", { name: regiao })).toBeInTheDocument();
+      });
+    });
+
+    it("renders the 'Período' select with placeholder and known periods", () => {
+      render(<PainelFiltros />);
+      const select = screen.getByLabelText("Período");
+      expect(select).toBeInTheDocument();
+      expect((select as HTMLSelectElement).value).toBe("");
+      PERIODOS.forEach((periodo) => {
+        expect(screen.getByRole("option", { name: periodo.label })).toBeInTheDocument();
+      });
+    });
+
+    it("renders the 'Limpar filtros' button and 'Buscar' field", () => {
+      render(<PainelFiltros />);
+      expect(screen.getByRole("button", { name: "Limpar filtros" })).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Buscar")).toBeInTheDocument();
+    });
+  });
+
+  describe("filter interactions", () => {
+    it("updates the selected região administrativa", () => {
+      render(<PainelFiltros />);
+      const select = screen.getByLabelText("Região Administrativa") as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: REGIOES_ADMINISTRATIVAS[0] } });
+      expect(select.value).toBe(REGIOES_ADMINISTRATIVAS[0]);
+    });
+
+    it("updates the selected período", () => {
+      render(<PainelFiltros />);
+      const select = screen.getByLabelText("Período") as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: PERIODOS[0].value } });
+      expect(select.value).toBe(PERIODOS[0].value);
+    });
+
+    it("updates the busca input value as the user types", () => {
+      render(<PainelFiltros />);
+      const input = screen.getByPlaceholderText("Buscar") as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "Ceilândia" } });
+      expect(input.value).toBe("Ceilândia");
+    });
+  });
+
+  describe("Limpar filtros (RF08)", () => {
+    it("resets região, período and busca to their initial state (edge: clear after filling)", () => {
+      render(<PainelFiltros />);
+      const regiaoSelect = screen.getByLabelText("Região Administrativa") as HTMLSelectElement;
+      const periodoSelect = screen.getByLabelText("Período") as HTMLSelectElement;
+      const buscaInput = screen.getByPlaceholderText("Buscar") as HTMLInputElement;
+
+      fireEvent.change(regiaoSelect, { target: { value: REGIOES_ADMINISTRATIVAS[0] } });
+      fireEvent.change(periodoSelect, { target: { value: PERIODOS[0].value } });
+      fireEvent.change(buscaInput, { target: { value: "texto qualquer" } });
+
+      fireEvent.click(screen.getByRole("button", { name: "Limpar filtros" }));
+
+      expect(regiaoSelect.value).toBe("");
+      expect(periodoSelect.value).toBe("");
+      expect(buscaInput.value).toBe("");
+    });
+  });
+
+  describe("expand/collapse (RNF05 - adherence to prototype)", () => {
+    it("starts expanded, showing the filter body", () => {
+      render(<PainelFiltros />);
+      expect(screen.getByLabelText("Região Administrativa")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Recolher filtros" })).toBeInTheDocument();
+    });
+
+    it("hides the filter body when the collapse button is clicked", () => {
+      render(<PainelFiltros />);
+      fireEvent.click(screen.getByRole("button", { name: "Recolher filtros" }));
+      expect(screen.queryByLabelText("Região Administrativa")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Período")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Expandir filtros" })).toBeInTheDocument();
+    });
+
+    it("keeps the 'Buscar' field visible when the filter body is collapsed (edge: independent sections)", () => {
+      render(<PainelFiltros />);
+      fireEvent.click(screen.getByRole("button", { name: "Recolher filtros" }));
+      expect(screen.getByPlaceholderText("Buscar")).toBeInTheDocument();
+    });
+
+    it("shows the filter body again when toggled twice (edge: re-expand)", () => {
+      render(<PainelFiltros />);
+      const toggle = () =>
+        fireEvent.click(screen.getByRole("button", { name: /^(Recolher|Expandir) filtros$/ }));
+      toggle();
+      toggle();
+      expect(screen.getByLabelText("Região Administrativa")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/__tests__/components/icons.test.tsx
+++ b/frontend/__tests__/components/icons.test.tsx
@@ -9,6 +9,7 @@ import {
   InfoIcon,
   PinIcon,
   ArrowRightIcon,
+  ChevronDownIcon,
 } from "@/components/icons";
 
 const ICONS = [
@@ -20,6 +21,7 @@ const ICONS = [
   { name: "InfoIcon", Component: InfoIcon },
   { name: "PinIcon", Component: PinIcon },
   { name: "ArrowRightIcon", Component: ArrowRightIcon },
+  { name: "ChevronDownIcon", Component: ChevronDownIcon },
 ];
 
 describe("Icon components", () => {

--- a/frontend/__tests__/utils/filtros.test.ts
+++ b/frontend/__tests__/utils/filtros.test.ts
@@ -1,0 +1,48 @@
+import { noticias } from "@/utils/noticias";
+import { REGIOES_ADMINISTRATIVAS, PERIODOS } from "@/utils/filtros";
+
+describe("filtros data", () => {
+  describe("REGIOES_ADMINISTRATIVAS", () => {
+    it("should be a non-empty array of strings", () => {
+      expect(Array.isArray(REGIOES_ADMINISTRATIVAS)).toBe(true);
+      expect(REGIOES_ADMINISTRATIVAS.length).toBeGreaterThan(0);
+      REGIOES_ADMINISTRATIVAS.forEach((regiao) => {
+        expect(typeof regiao).toBe("string");
+        expect(regiao.trim().length).toBeGreaterThan(0);
+      });
+    });
+
+    it("should contain known regions referenced in noticias", () => {
+      expect(REGIOES_ADMINISTRATIVAS).toContain("Ceilândia");
+      expect(REGIOES_ADMINISTRATIVAS).toContain("Taguatinga");
+    });
+
+    it("should not contain duplicate regions (edge: deduplication)", () => {
+      const unique = new Set(REGIOES_ADMINISTRATIVAS);
+      expect(unique.size).toBe(REGIOES_ADMINISTRATIVAS.length);
+    });
+
+    it("should match exactly the set of regions present in noticias", () => {
+      const regioesFromNoticias = new Set(noticias.map((n) => n.regiao));
+      expect(new Set(REGIOES_ADMINISTRATIVAS)).toEqual(regioesFromNoticias);
+    });
+  });
+
+  describe("PERIODOS", () => {
+    it("should be a non-empty array of options with value and label", () => {
+      expect(Array.isArray(PERIODOS)).toBe(true);
+      expect(PERIODOS.length).toBeGreaterThan(0);
+      PERIODOS.forEach((periodo) => {
+        expect(typeof periodo.value).toBe("string");
+        expect(periodo.value.trim().length).toBeGreaterThan(0);
+        expect(typeof periodo.label).toBe("string");
+        expect(periodo.label.trim().length).toBeGreaterThan(0);
+      });
+    });
+
+    it("should not contain duplicate values (edge: deduplication)", () => {
+      const values = PERIODOS.map((p) => p.value);
+      expect(new Set(values).size).toBe(values.length);
+    });
+  });
+});

--- a/frontend/components/PainelFiltros/PainelFiltros.module.css
+++ b/frontend/components/PainelFiltros/PainelFiltros.module.css
@@ -1,0 +1,131 @@
+.painel {
+  position: absolute;
+  top: 84px;
+  right: 24px;
+  bottom: 24px;
+  z-index: 500;
+  width: 320px;
+  min-height: 540px;
+  display: flex;
+  flex-direction: column;
+  background: var(--cor-superficie);
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  padding: 20px;
+  font-family: var(--font-body);
+}
+
+.cabecalho {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.titulo {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--cor-verde);
+  letter-spacing: 0.05em;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: var(--cor-amarelo);
+  cursor: pointer;
+}
+
+.chevronAberto {
+  transform: rotate(0deg);
+}
+
+.chevronFechado {
+  transform: rotate(-90deg);
+}
+
+.corpo {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--cor-texto);
+}
+
+.select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--cor-linha);
+  border-radius: 8px;
+  background: var(--cor-superficie);
+  color: var(--cor-texto);
+  font-size: 0.9rem;
+  font-family: var(--font-body);
+}
+
+.limparFiltros {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--cor-verde);
+  border-radius: 8px;
+  background: var(--cor-superficie);
+  color: var(--cor-verde);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.divisoria {
+  border: none;
+  border-top: 1px solid var(--cor-linha);
+  margin: 16px 0;
+}
+
+.buscaSection {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 16px;
+}
+
+.buscaContainer {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.buscaInput {
+  width: 100%;
+  padding: 12px 40px 12px 16px;
+  border: none;
+  border-radius: 24px;
+  background: var(--cor-fundo);
+  color: var(--cor-texto);
+  font-size: 0.95rem;
+  font-family: var(--font-body);
+}
+
+.buscaIcone {
+  position: absolute;
+  right: 14px;
+}
+
+.resultados {
+  flex: 1;
+}

--- a/frontend/components/PainelFiltros/PainelFiltros.tsx
+++ b/frontend/components/PainelFiltros/PainelFiltros.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDownIcon, SearchIcon } from "@/components/icons";
+import { REGIOES_ADMINISTRATIVAS, PERIODOS } from "@/utils/filtros";
+import styles from "./PainelFiltros.module.css";
+
+const INITIAL_STATE = {
+  regiao: "",
+  periodo: "",
+  busca: "",
+};
+
+export default function PainelFiltros() {
+  const [regiao, setRegiao] = useState(INITIAL_STATE.regiao);
+  const [periodo, setPeriodo] = useState(INITIAL_STATE.periodo);
+  const [busca, setBusca] = useState(INITIAL_STATE.busca);
+  const [expandido, setExpandido] = useState(true);
+
+  function handleLimparFiltros() {
+    setRegiao(INITIAL_STATE.regiao);
+    setPeriodo(INITIAL_STATE.periodo);
+    setBusca(INITIAL_STATE.busca);
+  }
+
+  return (
+    <section className={styles.painel} aria-label="Filtros de busca">
+      <div className={styles.cabecalho}>
+        <h2 className={styles.titulo}>FILTROS</h2>
+        <button
+          type="button"
+          className={styles.toggle}
+          aria-label={expandido ? "Recolher filtros" : "Expandir filtros"}
+          onClick={() => setExpandido((prev) => !prev)}
+        >
+          <ChevronDownIcon
+            size={18}
+            color="var(--cor-verde-escuro)"
+            className={expandido ? styles.chevronAberto : styles.chevronFechado}
+          />
+        </button>
+      </div>
+
+      {expandido && (
+        <div className={styles.corpo}>
+          <div className={styles.campo}>
+            <label className={styles.label} htmlFor="filtro-regiao">
+              Região Administrativa
+            </label>
+            <select
+              id="filtro-regiao"
+              aria-label="Região Administrativa"
+              className={styles.select}
+              value={regiao}
+              onChange={(event) => setRegiao(event.target.value)}
+            >
+              <option value="">Escolha uma opção</option>
+              {REGIOES_ADMINISTRATIVAS.map((regiaoOpcao) => (
+                <option key={regiaoOpcao} value={regiaoOpcao}>
+                  {regiaoOpcao}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className={styles.campo}>
+            <label className={styles.label} htmlFor="filtro-periodo">
+              Período
+            </label>
+            <select
+              id="filtro-periodo"
+              aria-label="Período"
+              className={styles.select}
+              value={periodo}
+              onChange={(event) => setPeriodo(event.target.value)}
+            >
+              <option value="">Escolha uma opção</option>
+              {PERIODOS.map((periodoOpcao) => (
+                <option key={periodoOpcao.value} value={periodoOpcao.value}>
+                  {periodoOpcao.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <button type="button" className={styles.limparFiltros} onClick={handleLimparFiltros}>
+            Limpar filtros
+          </button>
+        </div>
+      )}
+
+      <hr className={styles.divisoria} />
+
+      <div className={styles.buscaSection}>
+        <div className={styles.buscaContainer}>
+          <input
+            type="text"
+            className={styles.buscaInput}
+            placeholder="Buscar"
+            value={busca}
+            onChange={(event) => setBusca(event.target.value)}
+          />
+          <SearchIcon size={18} color="var(--cor-cinza)" className={styles.buscaIcone} />
+        </div>
+        <div className={styles.resultados} aria-label="Resultados da busca" />
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/icons/index.tsx
+++ b/frontend/components/icons/index.tsx
@@ -90,3 +90,11 @@ export function ArrowRightIcon({ size = 16, color = "currentColor", className }:
     </svg>
   );
 }
+
+export function ChevronDownIcon({ size = 16, color = "currentColor", className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" className={className}>
+      <path d="M6 9l6 6 6-6" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/frontend/utils/filtros.ts
+++ b/frontend/utils/filtros.ts
@@ -1,0 +1,17 @@
+import { noticias } from "./noticias";
+
+export const REGIOES_ADMINISTRATIVAS: string[] = Array.from(
+  new Set(noticias.map((noticia) => noticia.regiao))
+).sort((a, b) => a.localeCompare(b));
+
+export type Periodo = {
+  value: string;
+  label: string;
+};
+
+export const PERIODOS: Periodo[] = [
+  { value: "7d", label: "Últimos 7 dias" },
+  { value: "30d", label: "Últimos 30 dias" },
+  { value: "3m", label: "Últimos 3 meses" },
+  { value: "1y", label: "Último ano" },
+];

--- a/frontend/view/Mapa/Mapa.module.css
+++ b/frontend/view/Mapa/Mapa.module.css
@@ -1,4 +1,5 @@
 .page {
+  position: relative;
   width: 100%;
   height: 100%;
 }

--- a/frontend/view/Mapa/Mapa.tsx
+++ b/frontend/view/Mapa/Mapa.tsx
@@ -1,10 +1,12 @@
 import MapaInterativo from "@/components/MapaInterativo/MapaInterativo";
+import PainelFiltros from "@/components/PainelFiltros/PainelFiltros";
 import styles from "./Mapa.module.css";
 
 export default function Mapa() {
   return (
     <div className={styles.page}>
       <MapaInterativo />
+      <PainelFiltros />
     </div>
   );
 }


### PR DESCRIPTION
## Descrição
Implementa o painel "FILTROS" do Dashboard de Busca (Épico 3) como um overlay sobreposto à rota `/mapa`, posicionado no canto superior direito, abaixo do Header, seguindo o protótipo de alta fidelidade.

O painel contém:
- Seletor de **Região Administrativa** (placeholder "Escolha uma opção" + lista de RAs derivada dos dados de notícias)
- Seletor de **Período** ("Últimos 7 dias", "Últimos 30 dias", "Últimos 3 meses", "Último ano")
- Botão **"Limpar filtros"**, que reseta região, período e busca ao estado inicial
- Campo **"Buscar"** com ícone de lupa
- Botão circular de **recolher/expandir** os campos de filtro

A seção de filtros (Região/Período/Limpar filtros) é recolhível, mas a seção de busca permanece sempre visível e independente, com espaço reservado abaixo da barra de busca para futuros resultados.

Foi adicionado um novo ícone `ChevronDownIcon` em `components/icons`, a camada de dados `utils/filtros.ts` (RAs e períodos), o componente `PainelFiltros` com seu CSS Module, e a documentação spec-driven em `frontend/Specs/Specs_dashboard_busca/` (spec, plan, tasks).

Nesta entrega os filtros funcionam como controles de UI com estado local (selecionar, digitar, limpar, recolher/expandir); a aplicação real dos filtros sobre marcadores/notícias é entrega futura, já documentada como fora de escopo.

## Tipo de mudança
<!-- Marque com um "x" -->
- [ ]  Bug fix
- [x]  Nova funcionalidade
- [ ]  Refatoração
- [ ]  Documentação
- [x]  Testes
- [ ]  Melhoria de performance

## Issue relacionada
Relacionado ao Épico 3 — RF06 (parcial), RF08, RNF05, US 3.3.1 (parcial), US 3.3.3

## Como testar
Passo a passo para validar
1. Em `frontend/`, rodar `npm install` (se necessário) e `npm run dev`
2. Acessar `http://localhost:3000/mapa`
3. Verificar que o painel "FILTROS" aparece sobreposto ao mapa, no canto superior direito, sem cobrir o Header/Drawer
4. Selecionar uma Região Administrativa (ex: Ceilândia) e um Período (ex: "Últimos 7 dias") e confirmar que os seletores refletem o valor escolhido
5. Digitar um texto no campo "Buscar" e confirmar que o valor é atualizado
6. Clicar em "Limpar filtros" e confirmar que região, período e busca voltam ao estado inicial
7. Clicar no botão circular de recolher/expandir e confirmar que apenas os campos de filtro (Região/Período/Limpar filtros) são ocultados, mantendo o campo "Buscar" sempre visível
8. Rodar `npm test` em `frontend/` e confirmar que toda a suíte passa (165 testes)

## Evidências (se aplicável)
Verificação visual feita localmente via Playwright (screenshots temporários, removidos após a verificação): painel renderizado como card branco arredondado, título "FILTROS" em verde com botão circular amarelo, seletores com "Escolha uma opção", botão "Limpar filtros" em estilo outline e campo "Buscar" com ícone de lupa — consistente com o protótipo.

## Impactos e riscos
- Mudança aditiva: adiciona um novo componente overlay à rota `/mapa`, sem alterar a renderização do mapa interativo existente.
- Único ajuste em arquivo compartilhado: `view/Mapa/Mapa.module.css` recebeu `position: relative` em `.page`, necessário para o posicionamento absoluto do painel — não afeta o layout do mapa ou do Header/Drawer.
- Nenhuma lógica de filtragem real é aplicada ainda; portanto não há risco de quebrar a exibição de dados existentes.

## Checklist
- [x] Código segue o padrão do projeto
- [x] Testes adicionados/atualizados (se necessário)
- [x] Testado localmente
- [x] Documentação atualizada (se necessário)

## Observações adicionais
- RF07 (mensagem "Nenhum resultado encontrado"), RF09 (gráficos de produtividade), RF10 (card de detalhes/"Ver detalhes") e RF11 (resumo por IA), além da aplicação real dos filtros sobre marcadores/notícias, ficam documentados como fora de escopo em `frontend/Specs/Specs_dashboard_busca/spec.md` e serão tratados em entregas futuras.
