### PR TITLE
Feat/frontend Detalhamento da noticia RF02

### DIFF
--- a/frontend/Specs/Specs_pg_inicial/constitution.md
+++ b/frontend/Specs/Specs_pg_inicial/constitution.md
@@ -38,7 +38,10 @@ que transforma notícias e dados públicos de segurança em informação útil p
 
 ## Convenções de código
 - Idioma do código: nomes de componentes e tipos em inglês ou português, mas **consistentes**.
-- Estrutura de pastas: App Router do Next.js (`app/`), componentes em `components/`,
-  estilos `.module.css` ao lado do componente, dados mockados em `data/`.
+- Estrutura de pastas: o código do frontend vive em `components/` (componentes
+  reutilizáveis, com `.module.css` ao lado), `view/` (telas montadas a partir dos
+  componentes), `style/` (tokens/estilos globais) e `utils/` (camada de dados mockados
+  e funções utilitárias). As pastas `app/` (App Router) e `public/` são exigidas pelo
+  Next.js: `app/` é mantida como camada fina de roteamento, apenas repassando para as `view/`.
 - Cada commit referencia o ID do requisito ou da tarefa (ex: `feat(RF01): feed de notícias`).
 - Realizar pelo menos um commit no momento da criação de um novo arquivo.

--- a/frontend/Specs/Specs_pg_inicial/plan.md
+++ b/frontend/Specs/Specs_pg_inicial/plan.md
@@ -1,7 +1,10 @@
-# Plano técnico — Feature 001: Página inicial estática + navegação
+# Plano técnico — Feature 001: Página inicial + navegação
 
 > Blueprint técnico derivado de `spec.md`. Respeita `.2026-1-SafeStreets\frontend\Specs\Specs_pg_inicial\constitution.md`.
 > Referência visual: protótipo de alta fidelidade do SafeStreets.
+>
+> **Status:** atualizado após a implementação para refletir a estrutura de pastas real
+> (`view/`, `style/`, `utils/`, `app/` como camada fina de roteamento) e a busca funcional.
 
 ## Stack (inalterada)
 - **Framework:** Next.js (App Router)
@@ -12,49 +15,62 @@
 - **Imagens:** logo do escudo otimizado via `next/image`
 
 ## Estrutura de pastas
+> Por decisão de arquitetura do frontend, o código vive em `components/`, `style/`,
+> `utils/` e `view/`. As pastas `app/` e `public/` são exigidas pelo Next.js (App Router
+> e estáticos), então `app/` é mantida como uma **camada fina de roteamento**: cada
+> `page.tsx` apenas importa e renderiza a `view` correspondente.
+
 ```
 app/
-  layout.tsx              # layout raiz (server) → envolve children com <Chrome>
-  globals.css             # reset + design tokens + fontes
-  page.tsx                # rota "/" → Início (Hero + NewsFeed)
-  page.module.css
+  layout.tsx              # layout raiz (server) → <SearchProvider> + <Chrome> envolvendo children
+  page.tsx                # rota "/"     → renderiza <Home />
   mapa/
-    page.tsx              # placeholder estático "Mapa de risco — Em breve"
-  sobre/
-    page.tsx              # "Sobre nós" (texto estático sobre o projeto)
+    page.tsx              # rota "/mapa" → renderiza <Mapa /> (entregue pela feature dashboard)
+view/
+  Home/
+    Home.tsx              # "use client": lê o termo de busca, filtra notícias e monta Hero + NewsFeed
+    Home.module.css
+  Mapa/
+    Mapa.tsx              # tela do mapa (feature dashboard de busca)
+    Mapa.module.css
 components/
   Chrome/
-    Chrome.tsx            # "use client" — estado do drawer; renderiza Header + Drawer + children + Footer
-    Chrome.module.css
+    Chrome.tsx            # "use client": estado do drawer; lê contexto de busca; Header + Drawer + children + Footer
+    Chrome.module.css     #              variante overlay/full-screen na rota /mapa
+  SearchProvider/
+    SearchProvider.tsx    # "use client": contexto de busca (query + setQuery) e hook useSearch
   Header/
-    Header.tsx            # barra clara: hambúrguer + Logo + campo de busca (visual)
+    Header.tsx            # barra clara: hambúrguer + Logo + input de busca (controlado por props)
     Header.module.css
   Drawer/
-    Drawer.tsx            # menu lateral (overlay): NAVEGAÇÃO, itens c/ ícone+seta, item ativo, rodapé
+    Drawer.tsx            # menu lateral: Início, Mapa de risco (rotas) e Sobre nós (link externo)
     Drawer.module.css
   Hero/
     Hero.tsx              # eyebrow + título + subtítulo (só na home)
     Hero.module.css
   NewsFeed/
-    NewsFeed.tsx          # título "Notícias" + contador + lista de NewsCard
+    NewsFeed.tsx          # título "Notícias" + contador + lista de NewsCard + estado vazio
     NewsFeed.module.css
   NewsCard/
-    NewsCard.tsx          # placeholder de imagem, badges, título, descrição, fonte, link "Ler notícia"
-    NewsCard.module.css
+    NewsCard.tsx          # badges (região + data), título, descrição, link "Ler notícia →"
+    NewsCard.module.css   # (sem imagem e sem fonte)
   Footer/
     Footer.tsx
     Footer.module.css
   Logo/
     Logo.tsx              # escudo (next/image) + marca "SafeStreets"
   icons/
-    index.tsx             # ícones SVG: Menu, Search, Close, Home, Map, Info, Pin, ArrowRight
-data/
-  noticias.ts             # tipo Noticia + 6 notícias de exemplo
+    index.tsx             # ícones SVG: Menu, Search, Close, Home, Map, Info, Pin, ArrowRight, ChevronDown
+style/
+  globals.css             # reset + design tokens + variáveis de fonte
+utils/
+  noticias.ts             # tipo Noticia + 6 notícias de exemplo (camada de dados)
+  busca.ts                # filtrarNoticias(lista, termo): filtro puro, sem acento e case-insensitive
 public/
-  logo-escudo.png         # logo fornecido
+  logo-escudo.png         # escudo usado no Header e no Drawer
 ```
 
-## Design tokens (em `globals.css`)
+## Design tokens (em `style/globals.css`)
 ```css
 :root {
   /* Marca (cores oficiais — sobrepõem o protótipo) */
@@ -68,7 +84,7 @@ public/
   --cor-fundo:        #f4f7f2;  /* off-white levemente esverdeado (fundo da página) */
   --cor-superficie:   #ffffff;  /* fundo de cards e barras */
   --cor-texto:        #2b2f2b;  /* corpo */
-  --cor-cinza:        #6b716b;  /* texto secundário, datas, fontes */
+  --cor-cinza:        #6b716b;  /* texto secundário, datas */
   --cor-linha:        #e3e8e3;  /* divisórias e bordas suaves */
 
   /* Tipografia */
@@ -80,55 +96,68 @@ public/
 
 ### Aplicação das cores/tipos
 - **Barra superior:** fundo `--cor-superficie`, divisória `--cor-linha`. Marca "Safe" em
-  `--cor-verde-escuro`, "Streets" em `--cor-amarelo` (font-display).
+  `--cor-verde-escuro`, "Streets" em `--cor-amarelo` (font-display). Input de busca com
+  borda `--cor-linha` que vira `--cor-verde` em foco.
 - **Hero:** eyebrow = pílula `--verde-tint` com texto `--cor-verde` em `--font-mono` (maiúsculas);
   título em `--cor-verde-escuro` (font-display, bold); subtítulo em `--cor-cinza`.
 - **NewsCard:** superfície branca, borda `--cor-linha`, cantos arredondados, sombra leve.
-  Placeholder de imagem = textura listrada em tons de `--verde-tint`/`--cor-verde` com rótulo
-  em `--font-mono`. Badge de região = pílula `--cor-amarelo`. Data e fonte em `--cor-cinza`/`--font-mono`.
-  Link "Ler notícia →" em `--cor-verde`.
+  Badge de região = pílula `--cor-amarelo`. Data em `--cor-cinza`/`--font-mono`.
+  Link "Ler notícia →" em `--cor-verde`, alinhado à direita no rodapé.
 - **Drawer:** painel `--cor-superficie` sobre backdrop escurecido; item ativo com fundo
   `--verde-tint` e caixa do ícone em `--cor-verde`; rótulo "NAVEGAÇÃO" em `--font-mono`.
 
 ## Modelo de dados (mock)
 ```ts
-// data/noticias.ts
+// utils/noticias.ts
 export type Noticia = {
   id: string;
   titulo: string;
   resumo: string;        // descrição breve exibida no card
-  regiao: string;        // ex: "Plano Piloto"  → rótulo do placeholder e badge
+  regiao: string;        // ex: "Plano Piloto"  → badge do card
   ra: string;            // ex: "RA-I"
   data: string;          // "dd/mm/aaaa"
-  fonte: string;         // ex: "Boletim de Segurança · SSP-DF"
-  // Campos para fases futuras (detalhe/mapa), fora do escopo do passo 1:
-  // risco?: "low" | "med" | "high"; corpo?: string[]; x?: number; y?: number;
+  fonte: string;         // ex: "Boletim de Segurança · SSP-DF" (não exibido no card; usado na busca)
 };
 
 export const noticias: Noticia[] = [ /* 6 itens do protótipo */ ];
 ```
 
-## Rotas
-| Rota     | Página        | Conteúdo nesta fase                                   |
-|----------|---------------|-------------------------------------------------------|
-| `/`      | Início        | Header + Drawer + Hero + NewsFeed (mock) + Footer     |
-| `/mapa`  | Mapa de risco | Header + Drawer + placeholder "Em breve" + Footer     |
-| `/sobre` | Sobre nós     | Header + Drawer + texto sobre o projeto + Footer      |
+## Busca (RF08)
+- **Estado:** `SearchProvider` (contexto React client) guarda `query` + `setQuery`, com
+  valores-padrão seguros (`query: ""`, `setQuery` no-op) para componentes usados fora do provider.
+- **Entrada:** o `Header` é apresentacional — recebe `searchQuery` e `onSearchChange` por
+  props. O `Chrome` lê o contexto (`useSearch`) e injeta esses props no `Header`.
+- **Filtro:** `utils/busca.ts` expõe `filtrarNoticias(lista, termo)` — função pura que
+  normaliza (minúsculas, sem acentos, trim) e casa o termo contra título, resumo, região e fonte.
+- **Saída:** `Home` (client) lê `useSearch`, aplica `filtrarNoticias` sobre os mocks e
+  passa a lista filtrada ao `NewsFeed`. Lista vazia → estado "Nenhuma notícia encontrada".
 
-Navegação client-side com `<Link>` do `next/link`.
+## Rotas
+| Rota     | Página        | Conteúdo                                                  |
+|----------|---------------|----------------------------------------------------------|
+| `/`      | Início        | Header + Drawer + Hero + NewsFeed (mock, filtrável) + Footer |
+| `/mapa`  | Mapa de risco | Entregue pela feature **dashboard de busca** (Header overlay, sem Footer) |
+
+- "Sobre nós" **não é rota interna**: é um link externo (`<a target="_blank">`) para o
+  site institucional `https://unb-mds.github.io/2026-1-SafeStreets/`.
+- Navegação interna client-side com `<Link>` do `next/link`.
 
 ## Decisões técnicas
 | Decisão | Escolha | Por quê |
 |---|---|---|
-| Roteamento | App Router (`app/`) | Layout compartilhado simples; padrão atual do Next.js |
-| Estado do menu | `Chrome` é client component com `useState` para abrir/fechar o drawer | É a **única** interatividade do passo 1; o resto permanece estático |
-| Cores | Hex oficiais sobrepõem o protótipo | Protótipo usa `oklch` aproximado; a identidade oficial é `#016d01`/`#f8c311` |
-| Dados | Array tipado em `data/` | Isola a camada de dados (constituição §7); troca futura por API sem mexer nos componentes |
-| Busca / "Ler notícia" | Elementos visuais inertes | Busca (RF08) e detalhe (RF02) estão fora do escopo desta fase |
-| Imagem do card | Placeholder listrado | Sem imagens reais nesta fase; mantém fidelidade ao protótipo |
+| Roteamento | App Router (`app/`) como camada fina → `view/` | `app/` é exigida pelo Next.js; o conteúdo real fica em `view/` conforme a arquitetura do frontend |
+| Estrutura de pastas | `components/` / `style/` / `utils/` / `view/` | Arquitetura definida para o frontend; `data/` e CSS dentro de `app/` foram realocados |
+| Estado do menu | `Chrome` é client component com `useState` | Interatividade do shell (drawer) |
+| Estado da busca | Contexto `SearchProvider` + hook `useSearch` | Desacopla Header (publica o termo) de Home (consome e filtra); evita CSR forçado de `useSearchParams` e mantém `/` estática |
+| Cores | Hex oficiais sobrepõem o protótipo | A identidade oficial é `#016d01`/`#f8c311` |
+| Dados | Array tipado em `utils/noticias.ts` | Isola a camada de dados (constituição §7); troca futura por API sem mexer nos componentes |
+| Card | Sem imagem e sem fonte | Decisão de produto: o card mostra apenas região, data, título, descrição e o CTA |
+| "Sobre nós" | Link externo ao site institucional | Não há página interna "Sobre"; o conteúdo vive no site do projeto |
+| "Ler notícia" | Visual inerte | Detalhe da notícia (RF02) fica para fase posterior |
 
 ## Riscos / atenção
 - **Não acoplar componentes ao formato do mock.** `NewsCard` recebe uma `Noticia` por props;
   quando vier API, só a origem dos dados muda.
 - O layout raiz não deve duplicar Header/Drawer/Footer por página — isso vive no `Chrome`.
-- Manter `Chrome` enxuto: só o estado de abrir/fechar o menu. Nada de lógica de dados aqui.
+- Manter `Chrome` enxuto: estado do drawer + repasse do termo de busca ao Header. Sem lógica de dados.
+- Manter o filtro de busca como função pura em `utils/` (testável isoladamente, reaproveitável).

--- a/frontend/Specs/Specs_pg_inicial/plan.md
+++ b/frontend/Specs/Specs_pg_inicial/plan.md
@@ -26,6 +26,9 @@ app/
   page.tsx                # rota "/"     → renderiza <Home />
   mapa/
     page.tsx              # rota "/mapa" → renderiza <Mapa /> (entregue pela feature dashboard)
+  noticia/
+    [id]/
+      page.tsx           # rota "/noticia/{id}" → busca a notícia por id e renderiza <NoticiaDetalhe /> (notFound se não existir)
 view/
   Home/
     Home.tsx              # "use client": lê o termo de busca, filtra notícias e monta Hero + NewsFeed
@@ -33,6 +36,9 @@ view/
   Mapa/
     Mapa.tsx              # tela do mapa (feature dashboard de busca)
     Mapa.module.css
+  NoticiaDetalhe/
+    NoticiaDetalhe.tsx    # detalhamento (RF02): voltar, região, título, data, resumo, corpo, fonte original
+    NoticiaDetalhe.module.css
 components/
   Chrome/
     Chrome.tsx            # "use client": estado do drawer; lê contexto de busca; Header + Drawer + children + Footer
@@ -64,7 +70,7 @@ components/
 style/
   globals.css             # reset + design tokens + variáveis de fonte
 utils/
-  noticias.ts             # tipo Noticia + 6 notícias de exemplo (camada de dados)
+  noticias.ts             # tipo Noticia + 6 notícias de exemplo + getNoticiaPorId(id) (camada de dados)
   busca.ts                # filtrarNoticias(lista, termo): filtro puro, sem acento e case-insensitive
 public/
   logo-escudo.png         # escudo usado no Header e no Drawer
@@ -117,9 +123,14 @@ export type Noticia = {
   ra: string;            // ex: "RA-I"
   data: string;          // "dd/mm/aaaa"
   fonte: string;         // ex: "Boletim de Segurança · SSP-DF" (não exibido no card; usado na busca)
+  corpo: string[];       // parágrafos da descrição detalhada (RF02)
+  fonteUrl: string;      // link da fonte de dados original (RF02)
 };
 
 export const noticias: Noticia[] = [ /* 6 itens do protótipo */ ];
+
+// Lookup usado pela rota de detalhe:
+export function getNoticiaPorId(id: string): Noticia | undefined;
 ```
 
 ## Busca (RF08)
@@ -135,8 +146,9 @@ export const noticias: Noticia[] = [ /* 6 itens do protótipo */ ];
 ## Rotas
 | Rota     | Página        | Conteúdo                                                  |
 |----------|---------------|----------------------------------------------------------|
-| `/`      | Início        | Header + Drawer + Hero + NewsFeed (mock, filtrável) + Footer |
-| `/mapa`  | Mapa de risco | Entregue pela feature **dashboard de busca** (Header overlay, sem Footer) |
+| `/`            | Início        | Header + Drawer + Hero + NewsFeed (mock, filtrável) + Footer |
+| `/mapa`        | Mapa de risco | Entregue pela feature **dashboard de busca** (Header overlay, sem Footer) |
+| `/noticia/{id}`| Detalhe       | Header + Drawer + `NoticiaDetalhe` (SSG via `generateStaticParams`; `notFound` se id inválido) + Footer |
 
 - "Sobre nós" **não é rota interna**: é um link externo (`<a target="_blank">`) para o
   site institucional `https://unb-mds.github.io/2026-1-SafeStreets/`.
@@ -153,7 +165,8 @@ export const noticias: Noticia[] = [ /* 6 itens do protótipo */ ];
 | Dados | Array tipado em `utils/noticias.ts` | Isola a camada de dados (constituição §7); troca futura por API sem mexer nos componentes |
 | Card | Sem imagem e sem fonte | Decisão de produto: o card mostra apenas região, data, título, descrição e o CTA |
 | "Sobre nós" | Link externo ao site institucional | Não há página interna "Sobre"; o conteúdo vive no site do projeto |
-| "Ler notícia" | Visual inerte | Detalhe da notícia (RF02) fica para fase posterior |
+| Detalhe (RF02) | Rota dinâmica `/noticia/[id]` (server) + `NoticiaDetalhe` apresentacional | `page.tsx` faz o lookup por id e `notFound`; a view recebe a `Noticia` por props (testável e estática) |
+| Fonte original | `<a target="_blank">` para `fonteUrl` | Link real da fonte de dados; abre em nova aba |
 
 ## Riscos / atenção
 - **Não acoplar componentes ao formato do mock.** `NewsCard` recebe uma `Noticia` por props;

--- a/frontend/Specs/Specs_pg_inicial/spec.md
+++ b/frontend/Specs/Specs_pg_inicial/spec.md
@@ -1,8 +1,12 @@
-# Spec — Feature 001: Página inicial estática + navegação
+# Spec — Feature 001: Página inicial + navegação
 
 > O **quê** e o **porquê**. Sem detalhes de implementação (isso vai no PLAN).
 > Referência obrigatória: `.2026-1-SafeStreets\frontend\Specs\Specs_pg_inicial\constitution.md`
 > Referência visual: protótipo de alta fidelidade do SafeStreets (telas: página inicial + menu).
+>
+> **Status:** entregue. Esta spec foi atualizada após a implementação para refletir
+> o estado real da feature (campo de busca funcional, cards sem imagem e sem fonte,
+> "Sobre nós" como link externo).
 
 ## Problema
 O cidadão do DF não tem um lugar único e claro para se informar sobre ocorrências
@@ -11,13 +15,15 @@ entrada do produto** — uma página inicial informativa e a navegação princip
 de qualquer integração com dados reais.
 
 ## Objetivos desta entrega
-- [ ] Exibir uma página inicial com seção hero + feed de notícias de segurança (dados de exemplo/estáticos).
-- [ ] Disponibilizar um menu de navegação (drawer lateral) para "Início", "Mapa de risco" e "Sobre nós".
-- [ ] Aplicar a identidade visual do protótipo (logo, paleta, tipografia, cards).
+- [x] Exibir uma página inicial com seção hero + feed de notícias de segurança (dados de exemplo/estáticos).
+- [x] Disponibilizar um menu de navegação (drawer lateral) para "Início", "Mapa de risco" e "Sobre nós".
+- [x] Permitir buscar/filtrar o feed de notícias pelo campo de busca da barra superior.
+- [x] Aplicar a identidade visual do protótipo (logo, paleta, tipografia, cards).
 
 ## Requisitos cobertos
 - **RF01 — Visualizar página de notícia:** a página inicial exibe um feed de notícias sobre segurança.
 - **RF03 — Menu de navegação:** menu lateral com links diretos para "Início", "Mapa" e "Sobre nós".
+- **RF08 — Busca de notícias:** o campo da barra superior filtra o feed da home pelo termo digitado.
 
 ## User Stories
 - **US 1.1.1** — Como cidadão, quero acessar a página de informações sobre crimes na
@@ -27,31 +33,35 @@ de qualquer integração com dados reais.
 
 ## Layout de referência (protótipo)
 
-### Barra superior (em todas as páginas)
+### Barra superior (em todas as páginas, exceto sobre o mapa)
 - Fundo **claro** (off-white), fixa no topo, com divisória inferior sutil.
 - À esquerda: botão de menu (hambúrguer) + logo do escudo com a marca "SafeStreets"
-  ("Safe" em verde-escuro, "Streets" em amarelo). O logo está localizado em `.2026-1-SafeStreets\frontend\Specs\Specs_pg_inicial\imagens\logo-original.png`
+  ("Safe" em verde-escuro, "Streets" em amarelo). O escudo usado é `public/logo-escudo.png`.
 - À direita: campo de busca arredondado com ícone de lupa e placeholder
-  "Buscar" (**apenas visual nesta fase**).
+  "Buscar por região ou crime" — **funcional** (filtra o feed da home; ver RF08).
 
 ### Página inicial ("/")
 - **Hero:** etiqueta superior em destaque ("SEGURANÇA EM TEMPO REAL · DF" com ícone de pin),
   título grande em verde-escuro "Sua região, mais segura e transparente." e um parágrafo
   de apoio sobre acompanhar ocorrências e nível de risco.
-- **Seção "Notícias"**.
+- **Seção "Notícias"** com um contador de itens.
 - **Feed de cards.** Cada card contém, de cima para baixo:
-  - Área de imagem (por enquanto um *placeholder* com textura listrada e rótulo
-    "[ imagem · {região} ]"; sem imagem real nesta fase).
   - Badge de **região** (pílula amarela com ícone de pin) + badge de **data** (cinza, dd/mm/aaaa).
   - **Título** em negrito.
   - **Descrição** breve.
-  - Rodapé do card: **fonte** (ex.: "Boletim de Segurança · SSP-DF") + link "Ler notícia →".
+  - Rodapé do card: link "Ler notícia →" (alinhado à direita).
+  - *Sem* área de imagem e *sem* rótulo de fonte (removidos do card).
 
 ### Menu (drawer)
 - Abre **pela esquerda** ao clicar no hambúrguer, sobre um fundo escurecido (backdrop).
 - Topo: logo + botão de fechar (X).
 - Rótulo "NAVEGAÇÃO" e os itens, cada um com ícone à esquerda, rótulo e seta "→":
-  "Início", "Mapa de risco", "Sobre nós". O item da página atual aparece destacado (estado ativo).
+  - **Início** → rota interna `/`.
+  - **Mapa de risco** → rota interna `/mapa`.
+  - **Sobre nós** → **link externo** para `https://unb-mds.github.io/2026-1-SafeStreets/`
+    (abre em nova aba). Não é uma rota interna.
+- O item correspondente à rota interna atual aparece destacado (estado ativo). O link
+  externo "Sobre nós" nunca recebe estado ativo.
 - Rodapé do drawer com um texto curto descrevendo o produto.
 
 ## Critérios de aceitação
@@ -59,18 +69,30 @@ de qualquer integração com dados reais.
 ### RF01 — Feed de notícias
 - **Dado** que acesso "/", **quando** a página carrega, **então** vejo o hero, a seção
   "Notícias" e a lista de cards.
-- Cada card exibe placeholder de imagem, badge de região, data (dd/mm/aaaa), título,
-  descrição e fonte — na disposição do protótipo.
+- Cada card exibe badge de região, data (dd/mm/aaaa), título e descrição — na disposição
+  do protótipo, sem imagem e sem fonte.
 - O conteúdo vem de dados estáticos de exemplo (sem chamada de rede nesta fase).
 - A lista rola verticalmente quando há mais cards do que cabem na tela.
 
 ### RF03 — Menu de navegação
 - **Dado** que estou em qualquer página, **quando** clico no hambúrguer, **então** o
   drawer abre pela esquerda mostrando "Início", "Mapa de risco" e "Sobre nós".
-- **Quando** clico em um item, **então** sou levado à rota correspondente sem recarregar
-  a aplicação (navegação client-side) e o drawer fecha.
+- **Quando** clico em "Início" ou "Mapa de risco", **então** sou levado à rota
+  correspondente sem recarregar a aplicação (navegação client-side) e o drawer fecha.
+- **Quando** clico em "Sobre nós", **então** o site institucional abre em nova aba e o
+  drawer fecha.
 - O drawer também fecha ao clicar no X ou no fundo escurecido.
-- O item correspondente à página atual aparece em estado ativo.
+- O item correspondente à rota interna atual aparece em estado ativo.
+
+### RF08 — Busca de notícias
+- **Dado** que estou em "/", **quando** digito um termo no campo de busca da barra
+  superior, **então** o feed passa a mostrar apenas as notícias que correspondem ao termo.
+- A correspondência considera o texto da notícia (título, resumo, região e fonte), é
+  insensível a maiúsculas/minúsculas e a acentos (ex.: "ceilandia" encontra "Ceilândia").
+- **Quando** nenhuma notícia corresponde, **então** vejo a mensagem
+  "Nenhuma notícia encontrada para a sua busca.".
+- **Quando** limpo o campo, **então** o feed volta a exibir todas as notícias.
+- O campo de busca não aparece sobre a rota `/mapa`.
 
 ### Identidade visual
 - Paleta restrita: verde `#016d01`, amarelo `#f8c311`, branco `#ffffff` + cinzas/off-white auxiliares.
@@ -78,10 +100,10 @@ de qualquer integração com dados reais.
 - Logo do escudo presente na barra superior e no topo do drawer.
 
 ## Fora de escopo (NÃO fazer agora)
-- Qualquer backend, API ou banco de dados.
-- Busca funcional (o campo aparece, mas não filtra) — RF08, fase posterior.
-- Mapa interativo funcional: a rota `/mapa` é só um *placeholder* estático ("Em breve").
+- Qualquer backend, API ou banco de dados (a busca opera sobre os dados mockados).
 - Página de detalhe da notícia: o link "Ler notícia →" aparece, mas fica **inerte**
   nesta fase (RF02 — fase posterior).
-- Resumo de IA (RF14), filtros (RF06+), badges de risco e dashboard de busca.
+- Mapa interativo: a rota `/mapa` é entregue por outra feature (dashboard de busca),
+  fora do escopo desta spec.
+- Resumo de IA (RF14), badges de risco.
 - Responsividade mobile.

--- a/frontend/Specs/Specs_pg_inicial/spec.md
+++ b/frontend/Specs/Specs_pg_inicial/spec.md
@@ -18,10 +18,13 @@ de qualquer integração com dados reais.
 - [x] Exibir uma página inicial com seção hero + feed de notícias de segurança (dados de exemplo/estáticos).
 - [x] Disponibilizar um menu de navegação (drawer lateral) para "Início", "Mapa de risco" e "Sobre nós".
 - [x] Permitir buscar/filtrar o feed de notícias pelo campo de busca da barra superior.
+- [x] Abrir o detalhamento de uma notícia ao clicar em "Ler notícia".
 - [x] Aplicar a identidade visual do protótipo (logo, paleta, tipografia, cards).
 
 ## Requisitos cobertos
 - **RF01 — Visualizar página de notícia:** a página inicial exibe um feed de notícias sobre segurança.
+- **RF02 — Detalhamento da notícia:** ao clicar em "Ler notícia", o usuário vê a descrição
+  detalhada da ocorrência, a data de publicação, a localização associada e um link para a fonte original.
 - **RF03 — Menu de navegação:** menu lateral com links diretos para "Início", "Mapa" e "Sobre nós".
 - **RF08 — Busca de notícias:** o campo da barra superior filtra o feed da home pelo termo digitado.
 
@@ -49,8 +52,18 @@ de qualquer integração com dados reais.
   - Badge de **região** (pílula amarela com ícone de pin) + badge de **data** (cinza, dd/mm/aaaa).
   - **Título** em negrito.
   - **Descrição** breve.
-  - Rodapé do card: link "Ler notícia →" (alinhado à direita).
+  - Rodapé do card: link "Ler notícia →" (alinhado à direita) que leva ao
+    detalhamento da notícia (`/noticia/{id}`).
   - *Sem* área de imagem e *sem* rótulo de fonte (removidos do card).
+
+### Página de detalhe ("/noticia/{id}")
+- Link "← Voltar para notícias" no topo, que retorna para o feed (`/`).
+- Badge de **região** (localização associada) em pílula amarela com ícone de pin.
+- **Título** grande em verde-escuro.
+- **Data de publicação** (dd/mm/aaaa) em fonte mono.
+- **Resumo** em destaque, seguido do **corpo** da ocorrência (parágrafos da descrição detalhada).
+- Cartão "Acessar fonte original" com botão "Abrir link" que abre a **fonte de dados
+  original** em nova aba.
 
 ### Menu (drawer)
 - Abre **pela esquerda** ao clicar no hambúrguer, sobre um fundo escurecido (backdrop).
@@ -73,6 +86,16 @@ de qualquer integração com dados reais.
   do protótipo, sem imagem e sem fonte.
 - O conteúdo vem de dados estáticos de exemplo (sem chamada de rede nesta fase).
 - A lista rola verticalmente quando há mais cards do que cabem na tela.
+
+### RF02 — Detalhamento da notícia
+- **Dado** que estou no feed, **quando** clico em "Ler notícia" de um card, **então** sou
+  levado à página de detalhe daquela notícia (`/noticia/{id}`), sem recarregar a aplicação.
+- A página de detalhe exibe título, data de publicação, localização associada (região),
+  resumo e o corpo detalhado da ocorrência.
+- **Quando** clico em "Abrir link" no cartão de fonte, **então** a fonte original abre em nova aba.
+- **Quando** clico em "Voltar para notícias", **então** retorno ao feed (`/`).
+- **Dado** um id inexistente, **quando** acesso `/noticia/{id}`, **então** vejo a página de
+  "não encontrado" (404).
 
 ### RF03 — Menu de navegação
 - **Dado** que estou em qualquer página, **quando** clico no hambúrguer, **então** o
@@ -100,9 +123,8 @@ de qualquer integração com dados reais.
 - Logo do escudo presente na barra superior e no topo do drawer.
 
 ## Fora de escopo (NÃO fazer agora)
-- Qualquer backend, API ou banco de dados (a busca opera sobre os dados mockados).
-- Página de detalhe da notícia: o link "Ler notícia →" aparece, mas fica **inerte**
-  nesta fase (RF02 — fase posterior).
+- Qualquer backend, API ou banco de dados (busca e detalhe operam sobre os dados mockados;
+  a fonte original é um link externo real).
 - Mapa interativo: a rota `/mapa` é entregue por outra feature (dashboard de busca),
   fora do escopo desta spec.
 - Resumo de IA (RF14), badges de risco.

--- a/frontend/Specs/Specs_pg_inicial/tasks.md
+++ b/frontend/Specs/Specs_pg_inicial/tasks.md
@@ -56,6 +56,15 @@
 - [x] T027 Tornar o campo de busca do `Header` um input controlado; `Chrome` lê o contexto e repassa por props; `layout` envolve com `<SearchProvider>` — TDD: atualizar `Header.test.tsx`
 - [x] T028 `Home` filtra as notícias pelo termo e o `NewsFeed` exibe estado vazio — teste de integração `__tests__/view/Home.test.tsx`
 
+## Fase 10 — Detalhamento da notícia (RF02)
+- [x] T029 Estender o modelo `Noticia` com `corpo: string[]` e `fonteUrl: string` e adicionar
+      `getNoticiaPorId(id)` — `utils/noticias.ts` (+ testes de campos e do lookup)
+- [x] T030 Ícones `ArrowLeft` e `ExternalLink` — `components/icons/index.tsx`
+- [x] T031 `NewsCard`: "Ler notícia →" vira `<Link>` para `/noticia/{id}` — TDD: `NewsCard.test.tsx`
+- [x] T032 View `NoticiaDetalhe` (voltar, região, título, data, resumo, corpo, fonte original) —
+      `view/NoticiaDetalhe/` (+ `__tests__/view/NoticiaDetalhe.test.tsx`)
+- [x] T033 Rota dinâmica `app/noticia/[id]/page.tsx` (lookup por id, `notFound`, `generateStaticParams`, metadata)
+
 ## Critérios de pronto (Definition of Done)
 - [x] A rota `/` mostra barra superior, hero, seção "Notícias" e o feed de cards com dados de exemplo.
 - [x] Os cards exibem região, data, título e descrição — sem imagem e sem fonte.
@@ -66,5 +75,8 @@
 - [x] "Sobre nós" abre o site institucional em nova aba e fecha o drawer.
 - [x] O drawer também fecha pelo X e pelo backdrop.
 - [x] Visual fiel ao protótipo, dentro da paleta `#016d01` / `#f8c311` / `#ffffff`.
-- [x] "Ler notícia →" presente mas inerte; nenhuma chamada de rede, nenhum backend.
+- [x] "Ler notícia →" leva ao detalhamento da notícia (`/noticia/{id}`), que mostra título,
+      data, localização, resumo, corpo e link para a fonte original (abre em nova aba).
+- [x] Acessar um id inexistente em `/noticia/{id}` cai na página de "não encontrado" (404).
+- [x] Nenhuma chamada de rede a backend próprio; dados mockados; a fonte original é link externo.
 - [x] Suíte de testes (Jest + RTL) e `npm run build` passando.

--- a/frontend/Specs/Specs_pg_inicial/tasks.md
+++ b/frontend/Specs/Specs_pg_inicial/tasks.md
@@ -1,46 +1,70 @@
-# Tasks — Feature 001: Página inicial estática + navegação
+# Tasks — Feature 001: Página inicial + navegação
 
 > Referências: `spec.md`, `plan.md`, `.2026-1-SafeStreets\frontend\Specs\Specs_pg_inicial\constitution.md`
 > `[P]` = pode rodar em paralelo (não depende de outra tarefa em andamento).
 > Antes de cada mudança, o agente revisita spec.md e plan.md.
+>
+> Os caminhos refletem a **estrutura final** (`view/`, `style/`, `utils/`, `app/` fino).
+> As Fases 0–6 entregaram a versão estática inicial; as Fases 7–9 cobrem os ajustes
+> feitos depois sobre o protótipo (reestruturação, navegação externa, cards e busca).
 
 ## Fase 0 — Setup
-- [ ] T001 Inicializar projeto Next.js + TypeScript — raiz do repo
-- [ ] T002 Configurar fontes (Schibsted Grotesk, Plus Jakarta Sans, JetBrains Mono) via `next/font/google` — `app/layout.tsx`
-- [ ] T003 Definir design tokens + reset (cores oficiais, tipografia) — `app/globals.css`
-- [ ] T004 [P] Copiar o logo para `public/logo-original.png`
+- [x] T001 Inicializar projeto Next.js + TypeScript — `frontend/`
+- [x] T002 Configurar fontes (Schibsted Grotesk, Plus Jakarta Sans, JetBrains Mono) via `next/font/google` — `app/layout.tsx`
+- [x] T003 Definir design tokens + reset (cores oficiais, tipografia) — `style/globals.css`
+- [x] T004 [P] Copiar o logo do escudo para `public/logo-escudo.png`
 
 ## Fase 1 — Camada de dados (RF01)
-- [ ] T005 Criar tipo `Noticia` e as 6 notícias de exemplo do protótipo — `data/noticias.ts`
+- [x] T005 Criar tipo `Noticia` e as 6 notícias de exemplo do protótipo — `utils/noticias.ts`
 
 ## Fase 2 — Primitivas visuais
-- [ ] T006 [P] Ícones SVG (Menu, Search, Close, Home, Map, Info, Pin, ArrowRight) — `components/icons/index.tsx`
-- [ ] T007 [P] Componente `Logo` (escudo + marca "SafeStreets") — `components/Logo/Logo.tsx`
+- [x] T006 [P] Ícones SVG (Menu, Search, Close, Home, Map, Info, Pin, ArrowRight, ChevronDown) — `components/icons/index.tsx`
+- [x] T007 [P] Componente `Logo` (escudo + marca "SafeStreets") — `components/Logo/Logo.tsx`
 
 ## Fase 3 — Barra superior e menu (RF03)
-- [ ] T008 Componente `Header` (barra clara: hambúrguer + Logo + campo de busca visual) — `components/Header/Header.tsx` (+ `.module.css`) (depende: T006, T007)
-- [ ] T009 Componente `Drawer` (painel lateral + backdrop; itens Início / Mapa de risco / Sobre nós, com ícone, seta e estado ativo; rodapé) — `components/Drawer/Drawer.tsx` (+ `.module.css`) (depende: T006, T007)
-- [ ] T010 Componente `Chrome` ("use client": estado abrir/fechar do drawer; monta Header + Drawer + children + Footer) — `components/Chrome/Chrome.tsx` (+ `.module.css`) (depende: T008, T009, T013)
-- [ ] T011 [P] Componente `Footer` — `components/Footer/Footer.tsx` (+ `.module.css`)
+- [x] T008 Componente `Header` (barra clara: hambúrguer + Logo + campo de busca) — `components/Header/Header.tsx` (+ `.module.css`) (depende: T006, T007)
+- [x] T009 Componente `Drawer` (painel + backdrop; itens Início / Mapa de risco / Sobre nós, com ícone, seta e estado ativo; rodapé) — `components/Drawer/Drawer.tsx` (+ `.module.css`) (depende: T006, T007)
+- [x] T010 Componente `Chrome` ("use client": estado do drawer; monta Header + Drawer + children + Footer) — `components/Chrome/Chrome.tsx` (+ `.module.css`) (depende: T008, T009, T013)
+- [x] T011 [P] Componente `Footer` — `components/Footer/Footer.tsx` (+ `.module.css`)
 
 ## Fase 4 — Conteúdo da home (RF01)
-- [ ] T012 Componente `Hero` (eyebrow + título + subtítulo) — `components/Hero/Hero.tsx` (+ `.module.css`)
-- [ ] T013 Componente `NewsCard` (placeholder de imagem, badge de região, data, título, descrição, fonte, link "Ler notícia →" inerte) — `components/NewsCard/NewsCard.tsx` (+ `.module.css`) (depende: T006)
-- [ ] T014 Componente `NewsFeed` (título "Notícias" + contador + lista de `NewsCard`) — `components/NewsFeed/NewsFeed.tsx` (+ `.module.css`) (depende: T013)
+- [x] T012 Componente `Hero` (eyebrow + título + subtítulo) — `components/Hero/Hero.tsx` (+ `.module.css`)
+- [x] T013 Componente `NewsCard` (badges de região e data, título, descrição, link "Ler notícia →") — `components/NewsCard/NewsCard.tsx` (+ `.module.css`) (depende: T006)
+- [x] T014 Componente `NewsFeed` (título "Notícias" + contador + lista de `NewsCard`) — `components/NewsFeed/NewsFeed.tsx` (+ `.module.css`) (depende: T013)
 
 ## Fase 5 — Layout e rotas (RF03)
-- [ ] T015 Layout raiz envolvendo `children` com `<Chrome>` — `app/layout.tsx` (depende: T010)
-- [ ] T016 Página inicial: `Hero` + `NewsFeed` com os dados mock — `app/page.tsx` (depende: T005, T012, T014, T015)
-- [ ] T017 [P] Página placeholder do mapa ("Mapa de risco — Em breve") — `app/mapa/page.tsx` (depende: T015)
-- [ ] T018 [P] Página "Sobre nós" com texto do projeto — `app/sobre/page.tsx` (depende: T015)
+- [x] T015 Layout raiz envolvendo `children` com `<Chrome>` — `app/layout.tsx` (depende: T010)
+- [x] T016 Página inicial: `view/Home` (`Hero` + `NewsFeed`) com os dados mock — `app/page.tsx` → `view/Home/Home.tsx` (depende: T005, T012, T014, T015)
+- [x] T017 [P] Rota do mapa — `app/mapa/page.tsx` → `view/Mapa/Mapa.tsx` (conteúdo entregue pela feature dashboard de busca)
 
 ## Fase 6 — Ajuste fino visual
-- [ ] T019 Conferir aderência ao protótipo: cores (#016d01 / #f8c311), tipografia, cards, hero, drawer e estado ativo (depende: T016–T018)
+- [x] T018 Conferir aderência ao protótipo: cores (#016d01 / #f8c311), tipografia, cards, hero, drawer e estado ativo
+
+## Fase 7 — Reestruturação de pastas (arquitetura do frontend)
+- [x] T019 Mover dados mockados `data/noticias.ts` → `utils/noticias.ts` e atualizar imports
+- [x] T020 Mover `app/globals.css` → `style/globals.css` e atualizar o import no `layout.tsx`
+- [x] T021 Extrair conteúdo das páginas para `view/Home` e `view/Mapa`; manter `app/` como camada fina de roteamento
+
+## Fase 8 — Navegação "Sobre nós" externa
+- [x] T022 Transformar o item "Sobre nós" do `Drawer` em link externo (`https://unb-mds.github.io/2026-1-SafeStreets/`, nova aba) e remover a rota interna `/sobre`
+
+## Fase 9 — Cards e busca funcional
+- [x] T023 Remover a área de imagem do `NewsCard` (componente + CSS) — TDD: atualizar `NewsCard.test.tsx`
+- [x] T024 Remover a fonte do rodapé do `NewsCard` (mantida no modelo `Noticia` e na busca) — TDD: atualizar `NewsCard.test.tsx`
+- [x] T025 Criar filtro puro `filtrarNoticias` (case/acento-insensitive) — `utils/busca.ts` (+ `__tests__/utils/busca.test.ts`)
+- [x] T026 Criar `SearchProvider` (contexto `query`/`setQuery` + hook `useSearch`) — `components/SearchProvider/SearchProvider.tsx` (+ teste)
+- [x] T027 Tornar o campo de busca do `Header` um input controlado; `Chrome` lê o contexto e repassa por props; `layout` envolve com `<SearchProvider>` — TDD: atualizar `Header.test.tsx`
+- [x] T028 `Home` filtra as notícias pelo termo e o `NewsFeed` exibe estado vazio — teste de integração `__tests__/view/Home.test.tsx`
 
 ## Critérios de pronto (Definition of Done)
-- A rota `/` mostra barra superior, hero, seção "Notícias" e o feed de cards com dados de exemplo.
-- O hambúrguer abre o drawer pela esquerda; itens navegam entre `/`, `/mapa` e `/sobre`,
-  fecham o drawer e marcam a página atual como ativa.
-- O drawer também fecha pelo X e pelo backdrop.
-- Visual fiel ao protótipo, dentro da paleta `#016d01` / `#f8c311` / `#ffffff`.
-- Busca e "Ler notícia →" presentes mas inertes; nenhuma chamada de rede, nenhum backend.
+- [x] A rota `/` mostra barra superior, hero, seção "Notícias" e o feed de cards com dados de exemplo.
+- [x] Os cards exibem região, data, título e descrição — sem imagem e sem fonte.
+- [x] O campo de busca filtra o feed por título/resumo/região/fonte (case/acento-insensitive),
+      com mensagem de vazio quando nada corresponde; some na rota `/mapa`.
+- [x] O hambúrguer abre o drawer pela esquerda; "Início" e "Mapa de risco" navegam client-side
+      entre `/` e `/mapa`, fecham o drawer e marcam a rota atual como ativa.
+- [x] "Sobre nós" abre o site institucional em nova aba e fecha o drawer.
+- [x] O drawer também fecha pelo X e pelo backdrop.
+- [x] Visual fiel ao protótipo, dentro da paleta `#016d01` / `#f8c311` / `#ffffff`.
+- [x] "Ler notícia →" presente mas inerte; nenhuma chamada de rede, nenhum backend.
+- [x] Suíte de testes (Jest + RTL) e `npm run build` passando.

--- a/frontend/__tests__/components/Header.test.tsx
+++ b/frontend/__tests__/components/Header.test.tsx
@@ -25,16 +25,23 @@ describe("Header", () => {
       expect(logoLink).toHaveAttribute("href", "/");
     });
 
-    it("renders the visual search placeholder text", () => {
+    it("renders a search input with an accessible name and placeholder", () => {
       render(<Header onMenuClick={jest.fn()} />);
-      expect(screen.getByText(/Buscar por região/i)).toBeInTheDocument();
+      const input = screen.getByRole("searchbox", { name: /Buscar notícias/i });
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute("placeholder", expect.stringMatching(/Buscar por região/i));
+    });
+
+    it("reflects the searchQuery prop as the input value", () => {
+      render(<Header onMenuClick={jest.fn()} searchQuery="Ceilândia" />);
+      expect(screen.getByRole("searchbox")).toHaveValue("Ceilândia");
     });
   });
 
   describe("overlay variant (rota /mapa)", () => {
     it("does not render the search box", () => {
       render(<Header onMenuClick={jest.fn()} overlay />);
-      expect(screen.queryByText(/Buscar por região/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
     });
 
     it("still renders the menu button and logo", () => {
@@ -66,6 +73,24 @@ describe("Header", () => {
       render(<Header onMenuClick={() => {}} />);
       expect(() =>
         fireEvent.click(screen.getByRole("button", { name: /Abrir menu/i }))
+      ).not.toThrow();
+    });
+
+    it("calls onSearchChange with the typed value when the user types", () => {
+      const onSearchChange = jest.fn();
+      render(<Header onMenuClick={jest.fn()} onSearchChange={onSearchChange} />);
+      fireEvent.change(screen.getByRole("searchbox"), {
+        target: { value: "furtos" },
+      });
+      expect(onSearchChange).toHaveBeenCalledWith("furtos");
+    });
+
+    it("does not throw when typing without an onSearchChange handler (edge: missing handler)", () => {
+      render(<Header onMenuClick={jest.fn()} />);
+      expect(() =>
+        fireEvent.change(screen.getByRole("searchbox"), {
+          target: { value: "x" },
+        })
       ).not.toThrow();
     });
   });

--- a/frontend/__tests__/components/NewsCard.test.tsx
+++ b/frontend/__tests__/components/NewsCard.test.tsx
@@ -38,9 +38,9 @@ describe("NewsCard", () => {
       expect(screen.getByText("02/06/2026")).toBeInTheDocument();
     });
 
-    it("displays the fonte", () => {
+    it("does not display the fonte on the card", () => {
       render(<NewsCard noticia={baseNoticia} />);
-      expect(screen.getByText("SSP-DF")).toBeInTheDocument();
+      expect(screen.queryByText("SSP-DF")).not.toBeInTheDocument();
     });
 
     it("renders the 'Ler notícia' call-to-action", () => {
@@ -83,29 +83,17 @@ describe("NewsCard", () => {
       expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("X");
     });
 
-    it("renders correctly when fonte contains bullet separator (edge: composite string)", () => {
-      const noticia: Noticia = {
-        ...baseNoticia,
-        fonte: "Boletim de Segurança · SSP-DF",
-      };
-      render(<NewsCard noticia={noticia} />);
-      expect(
-        screen.getByText("Boletim de Segurança · SSP-DF")
-      ).toBeInTheDocument();
-    });
-
     it("renders correctly when regiao has accented characters (edge: UTF-8)", () => {
       const noticia: Noticia = { ...baseNoticia, regiao: "Ceilândia" };
       render(<NewsCard noticia={noticia} />);
       expect(screen.getByText("Ceilândia")).toBeInTheDocument();
     });
 
-    it("renders the image placeholder section (edge: missing img graceful degradation)", () => {
+    it("does not render an image or image placeholder (edge: image removed from card)", () => {
       const { container } = render(<NewsCard noticia={baseNoticia} />);
-      const imagePlaceholder = container.querySelector(
-        "[aria-hidden='true']"
-      );
-      expect(imagePlaceholder).toBeInTheDocument();
+      expect(container.querySelector("img")).toBeNull();
+      // o antigo placeholder de imagem usava o rótulo "[ imagem · ... ]"
+      expect(screen.queryByText(/\[ imagem/)).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/__tests__/components/NewsCard.test.tsx
+++ b/frontend/__tests__/components/NewsCard.test.tsx
@@ -11,6 +11,8 @@ const baseNoticia: Noticia = {
   ra: "RA-I",
   data: "02/06/2026",
   fonte: "SSP-DF",
+  corpo: ["Parágrafo de corpo."],
+  fonteUrl: "https://exemplo.df.gov.br/",
 };
 
 describe("NewsCard", () => {
@@ -46,6 +48,12 @@ describe("NewsCard", () => {
     it("renders the 'Ler notícia' call-to-action", () => {
       render(<NewsCard noticia={baseNoticia} />);
       expect(screen.getByText(/Ler notícia/)).toBeInTheDocument();
+    });
+
+    it("links 'Ler notícia' to the detail route of the notícia (RF02)", () => {
+      render(<NewsCard noticia={baseNoticia} />);
+      const link = screen.getByRole("link", { name: /Ler notícia/i });
+      expect(link).toHaveAttribute("href", "/noticia/1");
     });
 
     it("renders an article element", () => {

--- a/frontend/__tests__/components/NewsFeed.test.tsx
+++ b/frontend/__tests__/components/NewsFeed.test.tsx
@@ -11,6 +11,8 @@ const makeNoticia = (id: string): Noticia => ({
   ra: "RA-I",
   data: "01/01/2026",
   fonte: "Fonte Teste",
+  corpo: [`Corpo da notícia ${id}.`],
+  fonteUrl: "https://exemplo.df.gov.br/",
 });
 
 describe("NewsFeed", () => {

--- a/frontend/__tests__/components/SearchProvider.test.tsx
+++ b/frontend/__tests__/components/SearchProvider.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SearchProvider, useSearch } from "@/components/SearchProvider/SearchProvider";
+
+// Componente de sonda que expõe o valor do contexto e um botão para alterá-lo.
+function Probe() {
+  const { query, setQuery } = useSearch();
+  return (
+    <div>
+      <span data-testid="query">{query}</span>
+      <button onClick={() => setQuery("nova busca")}>set</button>
+    </div>
+  );
+}
+
+describe("SearchProvider / useSearch", () => {
+  describe("happy path", () => {
+    it("inicia com query vazia e atualiza ao chamar setQuery", () => {
+      render(
+        <SearchProvider>
+          <Probe />
+        </SearchProvider>
+      );
+      expect(screen.getByTestId("query")).toHaveTextContent("");
+      fireEvent.click(screen.getByRole("button", { name: "set" }));
+      expect(screen.getByTestId("query")).toHaveTextContent("nova busca");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("fornece valores padrão seguros fora do provider (query vazia, setQuery no-op)", () => {
+      render(<Probe />);
+      expect(screen.getByTestId("query")).toHaveTextContent("");
+      // setQuery padrão é no-op: clicar não deve lançar nem alterar o valor
+      expect(() =>
+        fireEvent.click(screen.getByRole("button", { name: "set" }))
+      ).not.toThrow();
+      expect(screen.getByTestId("query")).toHaveTextContent("");
+    });
+  });
+});

--- a/frontend/__tests__/utils/busca.test.ts
+++ b/frontend/__tests__/utils/busca.test.ts
@@ -9,6 +9,8 @@ const makeNoticia = (over: Partial<Noticia>): Noticia => ({
   ra: "RA-I",
   data: "01/01/2026",
   fonte: "SSP-DF",
+  corpo: ["Parágrafo padrão."],
+  fonteUrl: "https://exemplo.df.gov.br/",
   ...over,
 });
 

--- a/frontend/__tests__/utils/busca.test.ts
+++ b/frontend/__tests__/utils/busca.test.ts
@@ -1,0 +1,95 @@
+import { filtrarNoticias } from "@/utils/busca";
+import type { Noticia } from "@/utils/noticias";
+
+const makeNoticia = (over: Partial<Noticia>): Noticia => ({
+  id: "1",
+  titulo: "Título padrão",
+  resumo: "Resumo padrão",
+  regiao: "Plano Piloto",
+  ra: "RA-I",
+  data: "01/01/2026",
+  fonte: "SSP-DF",
+  ...over,
+});
+
+const lista: Noticia[] = [
+  makeNoticia({
+    id: "1",
+    titulo: "Furtos a pedestres aumentam na 304 Sul",
+    regiao: "Plano Piloto",
+    fonte: "Boletim de Segurança · SSP-DF",
+  }),
+  makeNoticia({
+    id: "2",
+    titulo: "Operação reduz roubo de veículos",
+    resumo: "Força-tarefa recuperou 23 carros.",
+    regiao: "Taguatinga",
+    fonte: "Nota oficial · PMDF",
+  }),
+  makeNoticia({
+    id: "3",
+    titulo: "Queda nos crimes violentos",
+    regiao: "Ceilândia",
+    fonte: "Relatório Mensal · PCDF",
+  }),
+];
+
+describe("filtrarNoticias", () => {
+  describe("happy path", () => {
+    it("retorna a lista completa quando o termo é vazio", () => {
+      expect(filtrarNoticias(lista, "")).toEqual(lista);
+    });
+
+    it("filtra por região (case-insensitive)", () => {
+      const resultado = filtrarNoticias(lista, "taguatinga");
+      expect(resultado).toHaveLength(1);
+      expect(resultado[0].id).toBe("2");
+    });
+
+    it("filtra por palavra no título", () => {
+      const resultado = filtrarNoticias(lista, "Furtos");
+      expect(resultado).toHaveLength(1);
+      expect(resultado[0].id).toBe("1");
+    });
+
+    it("filtra por trecho do resumo", () => {
+      const resultado = filtrarNoticias(lista, "recuperou 23");
+      expect(resultado.map((n) => n.id)).toEqual(["2"]);
+    });
+
+    it("filtra por fonte", () => {
+      const resultado = filtrarNoticias(lista, "PCDF");
+      expect(resultado.map((n) => n.id)).toEqual(["3"]);
+    });
+
+    it("ignora acentos no termo e no conteúdo (Ceilândia ~ ceilandia)", () => {
+      const resultado = filtrarNoticias(lista, "ceilandia");
+      expect(resultado.map((n) => n.id)).toEqual(["3"]);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("retorna a lista completa quando o termo é só espaços", () => {
+      expect(filtrarNoticias(lista, "   ")).toEqual(lista);
+    });
+
+    it("retorna lista vazia quando nada corresponde", () => {
+      expect(filtrarNoticias(lista, "xyznãoexiste")).toEqual([]);
+    });
+
+    it("retorna lista vazia ao filtrar uma lista vazia", () => {
+      expect(filtrarNoticias([], "qualquer")).toEqual([]);
+    });
+
+    it("não muta a lista original", () => {
+      const copia = [...lista];
+      filtrarNoticias(lista, "taguatinga");
+      expect(lista).toEqual(copia);
+    });
+
+    it("ignora espaços nas extremidades do termo", () => {
+      const resultado = filtrarNoticias(lista, "  taguatinga  ");
+      expect(resultado.map((n) => n.id)).toEqual(["2"]);
+    });
+  });
+});

--- a/frontend/__tests__/utils/noticias.test.ts
+++ b/frontend/__tests__/utils/noticias.test.ts
@@ -1,4 +1,4 @@
-import { noticias, type Noticia } from "@/utils/noticias";
+import { noticias, getNoticiaPorId, type Noticia } from "@/utils/noticias";
 
 describe("noticias data", () => {
   describe("array structure", () => {
@@ -44,6 +44,42 @@ describe("noticias data", () => {
         expect(n.data.trim()).not.toBe("");
         expect(n.fonte.trim()).not.toBe("");
       });
+    });
+
+    it("should have a non-empty corpo (array of paragraphs) on every item (RF02)", () => {
+      noticias.forEach((n) => {
+        expect(Array.isArray(n.corpo)).toBe(true);
+        expect(n.corpo.length).toBeGreaterThan(0);
+        n.corpo.forEach((paragrafo) => {
+          expect(typeof paragrafo).toBe("string");
+          expect(paragrafo.trim().length).toBeGreaterThan(0);
+        });
+      });
+    });
+
+    it("should have a valid http(s) fonteUrl on every item (RF02)", () => {
+      noticias.forEach((n) => {
+        expect(typeof n.fonteUrl).toBe("string");
+        expect(n.fonteUrl).toMatch(/^https?:\/\/.+/);
+      });
+    });
+  });
+
+  describe("getNoticiaPorId", () => {
+    it("returns the matching notícia for an existing id (happy path)", () => {
+      const primeira = noticias[0];
+      const encontrada = getNoticiaPorId(primeira.id);
+      expect(encontrada).toBeDefined();
+      expect(encontrada?.id).toBe(primeira.id);
+      expect(encontrada?.titulo).toBe(primeira.titulo);
+    });
+
+    it("returns undefined for an unknown id (edge: not found)", () => {
+      expect(getNoticiaPorId("id-inexistente")).toBeUndefined();
+    });
+
+    it("returns undefined for an empty id (edge: empty string)", () => {
+      expect(getNoticiaPorId("")).toBeUndefined();
     });
   });
 

--- a/frontend/__tests__/view/Home.test.tsx
+++ b/frontend/__tests__/view/Home.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SearchProvider, useSearch } from "@/components/SearchProvider/SearchProvider";
+import Header from "@/components/Header/Header";
+import Home from "@/view/Home/Home";
+
+// Reproduz o wiring real (Chrome lê o contexto e o repassa ao Header) num
+// harness enxuto, para testar a busca de ponta a ponta: Header → contexto →
+// Home → NewsFeed.
+function Harness() {
+  const { query, setQuery } = useSearch();
+  return (
+    <>
+      <Header
+        onMenuClick={() => {}}
+        searchQuery={query}
+        onSearchChange={setQuery}
+      />
+      <Home />
+    </>
+  );
+}
+
+function renderHome() {
+  return render(
+    <SearchProvider>
+      <Harness />
+    </SearchProvider>
+  );
+}
+
+describe("Home — busca funcional (RF08)", () => {
+  describe("happy path", () => {
+    it("exibe todas as notícias quando a busca está vazia", () => {
+      renderHome();
+      expect(screen.getByText(/Furtos a pedestres aumentam 14%/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Ceilândia registra queda de 18%/)
+      ).toBeInTheDocument();
+    });
+
+    it("filtra o feed pelo termo digitado no header", () => {
+      renderHome();
+      fireEvent.change(screen.getByRole("searchbox"), {
+        target: { value: "Ceilândia" },
+      });
+      expect(
+        screen.getByText(/Ceilândia registra queda de 18%/)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Furtos a pedestres aumentam 14%/)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("mostra mensagem de vazio quando nenhuma notícia corresponde", () => {
+      renderHome();
+      fireEvent.change(screen.getByRole("searchbox"), {
+        target: { value: "termo-inexistente-xyz" },
+      });
+      expect(
+        screen.getByText(/Nenhuma notícia encontrada/)
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("article")).not.toBeInTheDocument();
+    });
+
+    it("volta a exibir todas ao limpar a busca", () => {
+      renderHome();
+      const input = screen.getByRole("searchbox");
+      fireEvent.change(input, { target: { value: "Ceilândia" } });
+      fireEvent.change(input, { target: { value: "" } });
+      expect(screen.getByText(/Furtos a pedestres aumentam 14%/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Ceilândia registra queda de 18%/)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/__tests__/view/NoticiaDetalhe.test.tsx
+++ b/frontend/__tests__/view/NoticiaDetalhe.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import NoticiaDetalhe from "@/view/NoticiaDetalhe/NoticiaDetalhe";
+import type { Noticia } from "@/utils/noticias";
+
+const noticia: Noticia = {
+  id: "1",
+  titulo: "Furtos a pedestres aumentam 14% na quadra comercial da 304 Sul",
+  resumo: "Câmeras e patrulhamento a pé serão reforçados após série de ocorrências.",
+  regiao: "Plano Piloto",
+  ra: "RA-I",
+  data: "02/06/2026",
+  fonte: "Boletim de Segurança · SSP-DF",
+  corpo: [
+    "Primeiro parágrafo do detalhamento da ocorrência.",
+    "Segundo parágrafo com mais contexto sobre o caso.",
+  ],
+  fonteUrl: "https://www.ssp.df.gov.br/",
+};
+
+describe("NoticiaDetalhe (RF02)", () => {
+  describe("happy path", () => {
+    it("renders the title as an h1", () => {
+      render(<NoticiaDetalhe noticia={noticia} />);
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+        noticia.titulo
+      );
+    });
+
+    it("shows the publication date", () => {
+      render(<NoticiaDetalhe noticia={noticia} />);
+      expect(screen.getByText("02/06/2026")).toBeInTheDocument();
+    });
+
+    it("shows the associated location (região)", () => {
+      render(<NoticiaDetalhe noticia={noticia} />);
+      expect(screen.getByText("Plano Piloto")).toBeInTheDocument();
+    });
+
+    it("renders every body paragraph", () => {
+      render(<NoticiaDetalhe noticia={noticia} />);
+      noticia.corpo.forEach((paragrafo) => {
+        expect(screen.getByText(paragrafo)).toBeInTheDocument();
+      });
+    });
+
+    it("has a back link to the news feed", () => {
+      render(<NoticiaDetalhe noticia={noticia} />);
+      const voltar = screen.getByRole("link", { name: /Voltar para notícias/i });
+      expect(voltar).toHaveAttribute("href", "/");
+    });
+
+    it("links to the original source in a new tab", () => {
+      render(<NoticiaDetalhe noticia={noticia} />);
+      const link = screen.getByRole("link", { name: /Abrir link/i });
+      expect(link).toHaveAttribute("href", "https://www.ssp.df.gov.br/");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    });
+  });
+
+  describe("edge cases", () => {
+    it("renders without crashing when corpo has a single paragraph", () => {
+      const umParagrafo: Noticia = { ...noticia, corpo: ["Único parágrafo."] };
+      render(<NoticiaDetalhe noticia={umParagrafo} />);
+      expect(screen.getByText("Único parágrafo.")).toBeInTheDocument();
+    });
+
+    it("renders without crashing when corpo is empty (edge: no body)", () => {
+      const semCorpo: Noticia = { ...noticia, corpo: [] };
+      expect(() => render(<NoticiaDetalhe noticia={semCorpo} />)).not.toThrow();
+      expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+    });
+
+    it("escapes unicode/special characters in the title (edge: XSS-adjacent)", () => {
+      const xss: Noticia = { ...noticia, titulo: "<script>alert('x')</script>" };
+      const { container } = render(<NoticiaDetalhe noticia={xss} />);
+      expect(container.querySelector("script")).toBeNull();
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+        "<script>alert('x')</script>"
+      );
+    });
+  });
+});

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Schibsted_Grotesk, Plus_Jakarta_Sans, JetBrains_Mono } from "next/font/google";
 import Chrome from "@/components/Chrome/Chrome";
+import { SearchProvider } from "@/components/SearchProvider/SearchProvider";
 import "@/style/globals.css";
 
 const schibstedGrotesk = Schibsted_Grotesk({
@@ -37,7 +38,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       className={`${schibstedGrotesk.variable} ${plusJakartaSans.variable} ${jetbrainsMono.variable}`}
     >
       <body>
-        <Chrome>{children}</Chrome>
+        <SearchProvider>
+          <Chrome>{children}</Chrome>
+        </SearchProvider>
       </body>
     </html>
   );

--- a/frontend/app/noticia/[id]/page.tsx
+++ b/frontend/app/noticia/[id]/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { noticias, getNoticiaPorId } from "@/utils/noticias";
+import NoticiaDetalhe from "@/view/NoticiaDetalhe/NoticiaDetalhe";
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export function generateStaticParams() {
+  return noticias.map((noticia) => ({ id: noticia.id }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const noticia = getNoticiaPorId(id);
+  if (!noticia) {
+    return { title: "Notícia não encontrada — SafeStreets" };
+  }
+  return {
+    title: `${noticia.titulo} — SafeStreets`,
+    description: noticia.resumo,
+  };
+}
+
+export default async function NoticiaPage({ params }: PageProps) {
+  const { id } = await params;
+  const noticia = getNoticiaPorId(id);
+
+  if (!noticia) {
+    notFound();
+  }
+
+  return <NoticiaDetalhe noticia={noticia} />;
+}

--- a/frontend/components/Chrome/Chrome.tsx
+++ b/frontend/components/Chrome/Chrome.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import Header from "@/components/Header/Header";
 import Drawer from "@/components/Drawer/Drawer";
 import Footer from "@/components/Footer/Footer";
+import { useSearch } from "@/components/SearchProvider/SearchProvider";
 import styles from "./Chrome.module.css";
 
 interface ChromeProps {
@@ -15,10 +16,16 @@ export default function Chrome({ children }: ChromeProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const pathname = usePathname();
   const isMapRoute = pathname === "/mapa";
+  const { query, setQuery } = useSearch();
 
   return (
     <>
-      <Header onMenuClick={() => setDrawerOpen(true)} overlay={isMapRoute} />
+      <Header
+        onMenuClick={() => setDrawerOpen(true)}
+        overlay={isMapRoute}
+        searchQuery={query}
+        onSearchChange={setQuery}
+      />
       <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
       <main className={isMapRoute ? styles.mainFullScreen : styles.main}>
         {children}

--- a/frontend/components/Header/Header.module.css
+++ b/frontend/components/Header/Header.module.css
@@ -57,15 +57,31 @@
   border: 1.5px solid var(--cor-linha);
   border-radius: 999px;
   background-color: var(--cor-superficie);
-  cursor: default;
   min-width: 240px;
+  transition: border-color 0.15s;
 }
 
-.searchPlaceholder {
+.searchBox:focus-within {
+  border-color: var(--cor-verde);
+}
+
+.searchInput {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
   font-family: var(--font-body);
   font-size: 0.875rem;
+  color: var(--cor-texto);
+}
+
+.searchInput::placeholder {
   color: var(--cor-cinza);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+}
+
+/* Remove o "x" nativo do input type=search para manter o visual do protótipo */
+.searchInput::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
 }

--- a/frontend/components/Header/Header.tsx
+++ b/frontend/components/Header/Header.tsx
@@ -6,9 +6,16 @@ import styles from "./Header.module.css";
 interface HeaderProps {
   onMenuClick: () => void;
   overlay?: boolean;
+  searchQuery?: string;
+  onSearchChange?: (value: string) => void;
 }
 
-export default function Header({ onMenuClick, overlay = false }: HeaderProps) {
+export default function Header({
+  onMenuClick,
+  overlay = false,
+  searchQuery = "",
+  onSearchChange,
+}: HeaderProps) {
   return (
     <header
       className={overlay ? `${styles.header} ${styles.headerOverlay}` : styles.header}
@@ -28,9 +35,16 @@ export default function Header({ onMenuClick, overlay = false }: HeaderProps) {
 
       {!overlay && (
         <div className={styles.right}>
-          <div className={styles.searchBox} aria-label="Campo de busca (visual)">
+          <div className={styles.searchBox}>
             <SearchIcon size={16} color="var(--cor-cinza)" />
-            <span className={styles.searchPlaceholder}>Buscar por região ou crim...</span>
+            <input
+              type="search"
+              className={styles.searchInput}
+              placeholder="Buscar por região ou crime"
+              aria-label="Buscar notícias"
+              value={searchQuery}
+              onChange={(event) => onSearchChange?.(event.target.value)}
+            />
           </div>
         </div>
       )}

--- a/frontend/components/NewsCard/NewsCard.module.css
+++ b/frontend/components/NewsCard/NewsCard.module.css
@@ -11,39 +11,12 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.09);
 }
 
-/* ── Placeholder de imagem ── */
-.imagePlaceholder {
-  position: relative;
-  width: 100%;
-  height: 200px;
-  background-color: var(--verde-tint);
-  background-image: repeating-linear-gradient(
-    -45deg,
-    transparent,
-    transparent 8px,
-    rgba(1, 109, 1, 0.08) 8px,
-    rgba(1, 109, 1, 0.08) 10px
-  );
-  display: flex;
-  align-items: flex-end;
-  padding: 12px 16px;
-}
-
-.imageLabel {
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  color: var(--cor-cinza);
-  background-color: rgba(255, 255, 255, 0.75);
-  padding: 2px 8px;
-  border-radius: 4px;
-}
-
 /* ── Corpo do card ── */
 .body {
-  padding: 16px 20px 20px;
+  padding: 24px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
 }
 
 .badges {
@@ -93,17 +66,11 @@
 .cardFooter {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 8px;
-  padding-top: 4px;
+  padding-top: 12px;
   border-top: 1px solid var(--cor-linha);
   margin-top: 4px;
-}
-
-.fonte {
-  font-family: var(--font-body);
-  font-size: 0.8125rem;
-  color: var(--cor-cinza);
 }
 
 .lerNoticia {

--- a/frontend/components/NewsCard/NewsCard.tsx
+++ b/frontend/components/NewsCard/NewsCard.tsx
@@ -9,11 +9,6 @@ interface NewsCardProps {
 export default function NewsCard({ noticia }: NewsCardProps) {
   return (
     <article className={styles.card}>
-      {/* Placeholder de imagem */}
-      <div className={styles.imagePlaceholder} aria-hidden="true">
-        <span className={styles.imageLabel}>[ imagem · {noticia.regiao} ]</span>
-      </div>
-
       <div className={styles.body}>
         {/* Badges */}
         <div className={styles.badges}>
@@ -32,7 +27,6 @@ export default function NewsCard({ noticia }: NewsCardProps) {
 
         {/* Rodapé */}
         <div className={styles.cardFooter}>
-          <span className={styles.fonte}>{noticia.fonte}</span>
           <span className={styles.lerNoticia}>
             Ler notícia
             <ArrowRightIcon size={14} color="var(--cor-verde)" />

--- a/frontend/components/NewsCard/NewsCard.tsx
+++ b/frontend/components/NewsCard/NewsCard.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { Noticia } from "@/utils/noticias";
 import { PinIcon, ArrowRightIcon } from "@/components/icons";
 import styles from "./NewsCard.module.css";
@@ -27,10 +28,10 @@ export default function NewsCard({ noticia }: NewsCardProps) {
 
         {/* Rodapé */}
         <div className={styles.cardFooter}>
-          <span className={styles.lerNoticia}>
+          <Link href={`/noticia/${noticia.id}`} className={styles.lerNoticia}>
             Ler notícia
             <ArrowRightIcon size={14} color="var(--cor-verde)" />
-          </span>
+          </Link>
         </div>
       </div>
     </article>

--- a/frontend/components/NewsFeed/NewsFeed.module.css
+++ b/frontend/components/NewsFeed/NewsFeed.module.css
@@ -32,3 +32,13 @@
   max-width: 720px;
   margin: 0 auto;
 }
+
+.vazio {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 32px 0;
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  color: var(--cor-cinza);
+  text-align: center;
+}

--- a/frontend/components/NewsFeed/NewsFeed.tsx
+++ b/frontend/components/NewsFeed/NewsFeed.tsx
@@ -13,11 +13,17 @@ export default function NewsFeed({ noticias }: NewsFeedProps) {
         <h2 className={styles.sectionTitle}>Notícias</h2>
         <span className={styles.counter}>{noticias.length} recentes</span>
       </div>
-      <div className={styles.feed}>
-        {noticias.map((noticia) => (
-          <NewsCard key={noticia.id} noticia={noticia} />
-        ))}
-      </div>
+      {noticias.length === 0 ? (
+        <p className={styles.vazio}>
+          Nenhuma notícia encontrada para a sua busca.
+        </p>
+      ) : (
+        <div className={styles.feed}>
+          {noticias.map((noticia) => (
+            <NewsCard key={noticia.id} noticia={noticia} />
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/components/SearchProvider/SearchProvider.tsx
+++ b/frontend/components/SearchProvider/SearchProvider.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+
+type SearchContextValue = {
+  query: string;
+  setQuery: (query: string) => void;
+};
+
+const SearchContext = createContext<SearchContextValue>({
+  query: "",
+  setQuery: () => {},
+});
+
+export function SearchProvider({ children }: { children: React.ReactNode }) {
+  const [query, setQuery] = useState("");
+
+  return (
+    <SearchContext.Provider value={{ query, setQuery }}>
+      {children}
+    </SearchContext.Provider>
+  );
+}
+
+export function useSearch(): SearchContextValue {
+  return useContext(SearchContext);
+}

--- a/frontend/components/icons/index.tsx
+++ b/frontend/components/icons/index.tsx
@@ -98,3 +98,25 @@ export function ChevronDownIcon({ size = 16, color = "currentColor", className }
     </svg>
   );
 }
+
+export function ArrowLeftIcon({ size = 16, color = "currentColor", className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" className={className}>
+      <path d="M19 12H5M11 6l-6 6 6 6" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+export function ExternalLinkIcon({ size = 16, color = "currentColor", className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" className={className}>
+      <path
+        d="M15 3h6v6M21 3l-9 9M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/utils/busca.ts
+++ b/frontend/utils/busca.ts
@@ -1,0 +1,31 @@
+import type { Noticia } from "./noticias";
+
+/**
+ * Normaliza um texto para comparação de busca: minúsculas, sem acentos e sem
+ * espaços nas extremidades. Permite que "ceilandia" encontre "Ceilândia".
+ */
+function normalizar(texto: string): string {
+  return texto
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .trim();
+}
+
+/**
+ * Filtra a lista de notícias por um termo de busca, comparando contra título,
+ * resumo, região e fonte. Termo vazio retorna a lista original.
+ */
+export function filtrarNoticias(lista: Noticia[], termo: string): Noticia[] {
+  const termoNormalizado = normalizar(termo);
+  if (termoNormalizado.length === 0) {
+    return lista;
+  }
+
+  return lista.filter((noticia) => {
+    const alvo = normalizar(
+      `${noticia.titulo} ${noticia.resumo} ${noticia.regiao} ${noticia.fonte}`
+    );
+    return alvo.includes(termoNormalizado);
+  });
+}

--- a/frontend/utils/noticias.ts
+++ b/frontend/utils/noticias.ts
@@ -6,6 +6,8 @@ export type Noticia = {
   ra: string;
   data: string;
   fonte: string;
+  corpo: string[]; // parágrafos da descrição detalhada (RF02)
+  fonteUrl: string; // link original da fonte de dados (RF02)
 };
 
 export const noticias: Noticia[] = [
@@ -18,6 +20,12 @@ export const noticias: Noticia[] = [
     ra: "RA-I",
     data: "02/06/2026",
     fonte: "Boletim de Segurança · SSP-DF",
+    corpo: [
+      "A Administração Regional do Plano Piloto confirmou um aumento de 14% nos registros de furto a pedestres na quadra comercial da 304 Sul durante o último mês, concentrados no período entre 17h e 20h.",
+      "Segundo o boletim consolidado, a maior parte das ocorrências envolve celulares e bolsas subtraídos em pontos de ônibus e na saída de estabelecimentos comerciais. Não há registro de violência física na maioria dos casos.",
+      "Como resposta, a Secretaria de Segurança Pública anunciou o reforço do patrulhamento a pé no horário de pico e a instalação de quatro novas câmeras com leitura noturna. Moradores podem acompanhar a evolução dos índices pelo mapa interativo do SafeStreets.",
+    ],
+    fonteUrl: "https://www.ssp.df.gov.br/",
   },
   {
     id: "2",
@@ -28,6 +36,12 @@ export const noticias: Noticia[] = [
     ra: "RA-III",
     data: "01/06/2026",
     fonte: "Nota oficial · PMDF",
+    corpo: [
+      "A Operação Taguatinga Segura, deflagrada no início de maio, reduziu em 22% os roubos de veículos na região em comparação com o mesmo período do ano anterior.",
+      "A ação conjunta da Polícia Militar e da Polícia Civil resultou em oito prisões e na apreensão de dois veículos com sinais identificadores adulterados.",
+      "As forças de segurança informaram que o policiamento ostensivo nas principais vias de acesso será mantido pelos próximos meses.",
+    ],
+    fonteUrl: "https://www.pmdf.df.gov.br/",
   },
   {
     id: "3",
@@ -38,6 +52,12 @@ export const noticias: Noticia[] = [
     ra: "RA-IX",
     data: "31/05/2026",
     fonte: "Relatório Mensal · PCDF",
+    corpo: [
+      "Os crimes violentos contra a pessoa caíram 18% em Ceilândia no mês de maio, segundo o relatório mensal da Polícia Civil do Distrito Federal.",
+      "A delegacia especializada atribui o resultado ao aumento do efetivo nas regiões administrativas e à ampliação do videomonitoramento integrado.",
+      "O órgão ressalta que a tendência precisa ser confirmada nos próximos meses antes de ser considerada estrutural.",
+    ],
+    fonteUrl: "https://www.pcdf.df.gov.br/",
   },
   {
     id: "4",
@@ -48,6 +68,12 @@ export const noticias: Noticia[] = [
     ra: "RA-II",
     data: "30/05/2026",
     fonte: "Comunicado · GDF",
+    corpo: [
+      "Um novo posto policial foi inaugurado no Gama com foco no atendimento das comunidades rurais da região, historicamente com menor cobertura de policiamento.",
+      "A estrutura conta com equipes dedicadas ao patrulhamento das áreas de chácaras e assentamentos, além de um canal direto para denúncias.",
+      "O Governo do Distrito Federal afirma que outras unidades semelhantes estão previstas para regiões periféricas ao longo do ano.",
+    ],
+    fonteUrl: "https://www.df.gov.br/",
   },
   {
     id: "5",
@@ -58,6 +84,12 @@ export const noticias: Noticia[] = [
     ra: "RA-V",
     data: "29/05/2026",
     fonte: "Alerta de Segurança · PCDF",
+    corpo: [
+      "A Polícia Civil emitiu um alerta sobre o aumento de golpes envolvendo transferências via Pix em Sobradinho durante os fins de semana.",
+      "Os golpistas têm se passado por parentes e por funcionários de instituições financeiras para induzir vítimas a transferir valores rapidamente.",
+      "A orientação é não realizar transferências para desconhecidos, desconfiar de pedidos urgentes e ativar a dupla autenticação nos aplicativos bancários.",
+    ],
+    fonteUrl: "https://www.pcdf.df.gov.br/",
   },
   {
     id: "6",
@@ -68,5 +100,16 @@ export const noticias: Noticia[] = [
     ra: "RA-XII",
     data: "28/05/2026",
     fonte: "Boletim de Segurança · SSP-DF",
+    corpo: [
+      "Uma série de arrombamentos a comércios em Samambaia motivou o reforço do policiamento na região nas últimas semanas.",
+      "Câmeras de segurança flagraram os suspeitos, e duas pessoas foram detidas para averiguação na madrugada de sábado.",
+      "A Secretaria de Segurança Pública informou que as investigações seguem em andamento para identificar os demais envolvidos.",
+    ],
+    fonteUrl: "https://www.ssp.df.gov.br/",
   },
 ];
+
+/** Busca uma notícia pelo seu id. Retorna `undefined` se não existir. */
+export function getNoticiaPorId(id: string): Noticia | undefined {
+  return noticias.find((noticia) => noticia.id === id);
+}

--- a/frontend/view/Home/Home.tsx
+++ b/frontend/view/Home/Home.tsx
@@ -1,13 +1,20 @@
+"use client";
+
 import Hero from "@/components/Hero/Hero";
 import NewsFeed from "@/components/NewsFeed/NewsFeed";
 import { noticias } from "@/utils/noticias";
+import { filtrarNoticias } from "@/utils/busca";
+import { useSearch } from "@/components/SearchProvider/SearchProvider";
 import styles from "./Home.module.css";
 
 export default function Home() {
+  const { query } = useSearch();
+  const noticiasFiltradas = filtrarNoticias(noticias, query);
+
   return (
     <div className={styles.page}>
       <Hero />
-      <NewsFeed noticias={noticias} />
+      <NewsFeed noticias={noticiasFiltradas} />
     </div>
   );
 }

--- a/frontend/view/NoticiaDetalhe/NoticiaDetalhe.module.css
+++ b/frontend/view/NoticiaDetalhe/NoticiaDetalhe.module.css
@@ -1,0 +1,134 @@
+.page {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 32px 24px 64px;
+  display: flex;
+  flex-direction: column;
+}
+
+.voltar {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  align-self: flex-start;
+  margin-bottom: 28px;
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--cor-verde-escuro);
+  transition: opacity 0.15s;
+}
+
+.voltar:hover {
+  opacity: 0.7;
+}
+
+.badgeRegiao {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 5px 12px;
+  background-color: var(--cor-amarelo);
+  border-radius: 999px;
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--cor-verde-escuro);
+  margin-bottom: 16px;
+}
+
+.titulo {
+  font-family: var(--font-display);
+  font-size: clamp(1.9rem, 4vw, 2.75rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  color: var(--cor-verde-escuro);
+  margin-bottom: 16px;
+}
+
+.data {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--cor-cinza);
+  margin-bottom: 28px;
+}
+
+.resumo {
+  font-family: var(--font-body);
+  font-size: 1.15rem;
+  line-height: 1.6;
+  color: var(--cor-texto);
+  margin-bottom: 24px;
+}
+
+.corpo {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.corpo p {
+  font-family: var(--font-body);
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--cor-texto);
+}
+
+.fonteCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 40px;
+  padding: 20px 24px;
+  background-color: var(--cor-superficie);
+  border: 1px solid var(--cor-linha);
+  border-radius: 16px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+}
+
+.fonteInfo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.fonteIcone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background-color: var(--verde-tint);
+  flex-shrink: 0;
+}
+
+.fonteTexto {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--cor-verde-escuro);
+}
+
+.abrirLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border: 1px solid var(--cor-linha);
+  border-radius: 999px;
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--cor-verde-escuro);
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.abrirLink:hover {
+  border-color: var(--cor-verde);
+  background-color: var(--verde-tint);
+}

--- a/frontend/view/NoticiaDetalhe/NoticiaDetalhe.tsx
+++ b/frontend/view/NoticiaDetalhe/NoticiaDetalhe.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import type { Noticia } from "@/utils/noticias";
+import {
+  ArrowLeftIcon,
+  PinIcon,
+  ExternalLinkIcon,
+} from "@/components/icons";
+import styles from "./NoticiaDetalhe.module.css";
+
+interface NoticiaDetalheProps {
+  noticia: Noticia;
+}
+
+export default function NoticiaDetalhe({ noticia }: NoticiaDetalheProps) {
+  return (
+    <article className={styles.page}>
+      <Link href="/" className={styles.voltar}>
+        <ArrowLeftIcon size={16} color="var(--cor-verde-escuro)" />
+        Voltar para notícias
+      </Link>
+
+      <span className={styles.badgeRegiao}>
+        <PinIcon size={12} color="var(--cor-verde-escuro)" />
+        {noticia.regiao}
+      </span>
+
+      <h1 className={styles.titulo}>{noticia.titulo}</h1>
+
+      <p className={styles.data}>{noticia.data}</p>
+
+      <p className={styles.resumo}>{noticia.resumo}</p>
+
+      <div className={styles.corpo}>
+        {noticia.corpo.map((paragrafo, indice) => (
+          <p key={indice}>{paragrafo}</p>
+        ))}
+      </div>
+
+      <div className={styles.fonteCard}>
+        <div className={styles.fonteInfo}>
+          <span className={styles.fonteIcone}>
+            <ExternalLinkIcon size={18} color="var(--cor-verde)" />
+          </span>
+          <span className={styles.fonteTexto}>Acessar fonte original</span>
+        </div>
+        <a
+          href={noticia.fonteUrl}
+          className={styles.abrirLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Abrir link
+          <ExternalLinkIcon size={14} color="var(--cor-verde-escuro)" />
+        </a>
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
## Descrição
Implementa o **RF02 — Detalhamento da notícia**: ao clicar em "Ler notícia" em um card do feed, o usuário é levado a uma página de detalhe da ocorrência (`/noticia/{id}`), seguindo o protótipo de alta fidelidade.

A página de detalhe contém:
- Link **"← Voltar para notícias"** no topo, que retorna ao feed (`/`)
- Badge de **região** (localização associada) em pílula amarela com ícone de pin
- **Título** grande em verde-escuro
- **Data de publicação** (dd/mm/aaaa) em fonte mono
- **Resumo** em destaque, seguido do **corpo** da ocorrência (parágrafos da descrição detalhada)
- Cartão **"Acessar fonte original"** com botão **"Abrir link"**, que abre a fonte de dados original em nova aba

O link "Ler notícia →" do `NewsCard`, antes inerte, passou a navegar (client-side) para a rota de detalhe. O modelo `Noticia` foi estendido com `corpo: string[]` e `fonteUrl: string`, e ganhou o lookup `getNoticiaPorId(id)`. A rota `app/noticia/[id]/page.tsx` é uma camada fina (server) que faz o lookup por id, retorna `notFound()` (404) para ids inválidos, pré-renderiza as notícias via `generateStaticParams` e define metadata por notícia. A view `NoticiaDetalhe` é apresentacional (recebe a `Noticia` por props), mantendo a rota estática e a view testável isoladamente.

Foram adicionados os ícones `ArrowLeftIcon` e `ExternalLinkIcon` em `components/icons`, o componente de tela `view/NoticiaDetalhe/` com seu CSS Module, e a documentação spec-driven em `frontend/Specs/Specs_pg_inicial/` foi atualizada (spec, plan, tasks) para remover o RF02 de "fora de escopo".

## Tipo de mudança
<!-- Marque com um "x" -->
- [ ]  Bug fix
- [x]  Nova funcionalidade
- [ ]  Refatoração
- [ ]  Documentação
- [x]  Testes
- [ ]  Melhoria de performance

## Issue relacionada
Relacionado ao Épico 1 — RF02; #87 #86 #85 

## Como testar
Passo a passo para validar
1. Em `frontend/`, rodar `npm install` (se necessário) e `npm run dev`
2. Acessar `http://localhost:3000/`
3. No feed, clicar em "Ler notícia →" em qualquer card e confirmar a navegação para `/noticia/{id}` sem recarregar a aplicação
4. Verificar que a página de detalhe exibe título, data de publicação, região (localização associada), resumo e o corpo detalhado da ocorrência
5. Clicar em "Abrir link" no cartão de fonte e confirmar que a fonte original abre em nova aba
6. Clicar em "← Voltar para notícias" e confirmar o retorno ao feed (`/`)
7. Rodar `npm test` em `frontend/` e confirmar que toda a suíte passa (200 testes)

## Evidências (se aplicável)
Página de detalhe consistente com o protótipo: link de voltar no topo, badge de região em amarelo, título em verde-escuro, data em fonte mono, resumo em destaque seguido dos parágrafos do corpo, e cartão de fonte original com botão "Abrir link".

## Impactos e riscos
- Mudança majoritariamente aditiva: nova rota dinâmica + nova view, sem alterar o layout do feed nem do Header/Drawer.
- O modelo `Noticia` ganhou dois campos obrigatórios (`corpo`, `fonteUrl`); os mocks e os factories de teste foram atualizados de acordo.
- Único ajuste de comportamento existente: o link "Ler notícia →" do `NewsCard` deixou de ser inerte e agora navega para o detalhe.
- Dados continuam mockados; a fonte original é um link externo real. Sem backend próprio.

## Checklist
- [x] Código segue o padrão do projeto
- [x] Testes adicionados/atualizados (se necessário)
- [x] Testado localmente
- [x] Documentação atualizada (se necessário)

## Observações adicionais
- No header global, o campo de busca continua visível na rota de detalhe (como em qualquer rota fora de `/mapa`); digitá-lo não afeta a página de detalhe. Ocultá-lo no detalhe pode ser feito em ajuste futuro, se desejado.
- A página de detalhe usa dados mockados (`utils/noticias.ts`); a troca futura por API não altera os componentes, apenas a origem dos dados.