### PR TITLE
feat: implementação do banco de dados v2

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Instala dependências do sistema necessárias para o psycopg2
+RUN apt-get update && apt-get install -y \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copia e instala dependências Python
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copia o código da aplicação
+COPY . .
+
+# Porta exposta pelo FastAPI
+EXPOSE 8000
+
+# Comando padrão (sobrescrito pelo docker-compose.yml)
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,149 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+# Or organize into date-based subdirectories (requires recursive_version_locations = true)
+# file_template = %%(year)d/%%(month).2d/%%(day).2d_%%(hour).2d%%(minute).2d_%%(second).2d_%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the tzdata library which can be installed by adding
+# `alembic[tz]` to the pip requirements.
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/alembic/README
+++ b/backend/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,88 @@
+import os
+import sys
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# Garante que o pacote 'app' seja encontrado quando rodando alembic de /backend
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Importa Base e todos os models para que o autogenerate detecte as tabelas
+from app.core.database import Base
+from app.models import LocalPin, Ocorrencia, HistoricoConsulta  # noqa: F401
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Sobrescreve a URL do alembic.ini com a variável de ambiente (se disponível)
+_db_url = os.getenv("DATABASE_URL", "postgresql://admin:123@localhost:5432/safestreets")
+config.set_main_option("sqlalchemy.url", _db_url)
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Metadata de todos os models registrados — necessário para autogenerate
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/backend/alembic/versions/001_initial_schema.py
+++ b/backend/alembic/versions/001_initial_schema.py
@@ -1,0 +1,104 @@
+"""cria tabelas locais_pin ocorrencias_criminais e historico_consultas
+
+Revision ID: 001_initial_schema
+Revises:
+Create Date: 2026-06-16
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '001_initial_schema'
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── Tabela: locais_pin ───────────────────────────────────────────────────
+    op.create_table(
+        'locais_pin',
+        sa.Column('id',                    sa.Integer(),      nullable=False),
+        sa.Column('latitude',              sa.Numeric(9, 6),  nullable=False),
+        sa.Column('longitude',             sa.Numeric(9, 6),  nullable=False),
+        sa.Column('regiao_administrativa', sa.String(10),     nullable=False),
+        sa.Column('nome_regiao',           sa.String(100),    nullable=True),
+        sa.Column('tipo_localizacao',      sa.String(20),     nullable=True),
+        sa.Column('criado_em',             sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.CheckConstraint('latitude BETWEEN -90 AND 90',    name='chk_latitude'),
+        sa.CheckConstraint('longitude BETWEEN -180 AND 180', name='chk_longitude'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('idx_locais_pin_coords', 'locais_pin', ['latitude', 'longitude'],  unique=False)
+    op.create_index('idx_locais_pin_regiao', 'locais_pin', ['regiao_administrativa'],   unique=False)
+
+    # ── Tabela: ocorrencias_criminais ────────────────────────────────────────
+    op.create_table(
+        'ocorrencias_criminais',
+        sa.Column('id',                    sa.Integer(),       nullable=False),
+        sa.Column('locais_pin_id',         sa.Integer(),       nullable=False),
+        sa.Column('titulo_noticia',        sa.String(500),     nullable=False),
+        sa.Column('descricao_detalhada',   sa.Text(),          nullable=True),
+        sa.Column('fonte_url',             sa.String(2048),    nullable=True),
+        sa.Column('latitude',              sa.Numeric(9, 6),   nullable=False),
+        sa.Column('longitude',             sa.Numeric(9, 6),   nullable=False),
+        sa.Column('regiao_administrativa', sa.String(10),      nullable=False),
+        sa.Column('resumo_gemini',         sa.Text(),          nullable=True),
+        sa.Column('resumo_status',         sa.String(20),      nullable=True),
+        sa.Column('risco_nivel',           sa.String(10),      nullable=True),
+        sa.Column('data_ocorrencia',       sa.DateTime(timezone=True), nullable=False),
+        sa.Column('criado_em',             sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.Column('atualizado_em',         sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.CheckConstraint(
+            "resumo_status IN ('COMPLETO', 'PENDENTE', 'ERRO', 'FALLBACK_GENERICO')",
+            name='chk_resumo_status'
+        ),
+        sa.CheckConstraint(
+            "risco_nivel IN ('baixo', 'medio', 'alto')",
+            name='chk_risco_nivel'
+        ),
+        sa.ForeignKeyConstraint(['locais_pin_id'], ['locais_pin.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('idx_ocorrencias_pin',    'ocorrencias_criminais', ['locais_pin_id'],          unique=False)
+    op.create_index('idx_ocorrencias_regiao', 'ocorrencias_criminais', ['regiao_administrativa'],  unique=False)
+    op.create_index('idx_ocorrencias_data',   'ocorrencias_criminais', ['data_ocorrencia'],        unique=False)
+    # Índice parcial: só ocorrências pendentes de resumo
+    op.execute(
+        "CREATE INDEX idx_ocorrencias_status ON ocorrencias_criminais (resumo_status) "
+        "WHERE resumo_status = 'PENDENTE'"
+    )
+
+    # ── Tabela: historico_consultas ──────────────────────────────────────────
+    op.create_table(
+        'historico_consultas',
+        sa.Column('id',                           sa.Integer(),    nullable=False),
+        sa.Column('locais_pin_id',                sa.Integer(),    nullable=True),
+        sa.Column('timestamp_ultima_atualizacao', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('ttl_expiracao',                sa.DateTime(timezone=True), nullable=False),
+        sa.Column('raio_geografico',              sa.String(100),  nullable=True),
+        sa.Column('total_ocorrencias_cached',     sa.Integer(),    nullable=True),
+        sa.Column('criado_em',                    sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['locais_pin_id'], ['locais_pin.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('idx_historico_ttl', 'historico_consultas', ['ttl_expiracao'],  unique=False)
+    op.create_index('idx_historico_pin', 'historico_consultas', ['locais_pin_id'],  unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('idx_historico_pin',    table_name='historico_consultas')
+    op.drop_index('idx_historico_ttl',    table_name='historico_consultas')
+    op.drop_table('historico_consultas')
+
+    op.execute('DROP INDEX IF EXISTS idx_ocorrencias_status')
+    op.drop_index('idx_ocorrencias_data',   table_name='ocorrencias_criminais')
+    op.drop_index('idx_ocorrencias_regiao', table_name='ocorrencias_criminais')
+    op.drop_index('idx_ocorrencias_pin',    table_name='ocorrencias_criminais')
+    op.drop_table('ocorrencias_criminais')
+
+    op.drop_index('idx_locais_pin_regiao', table_name='locais_pin')
+    op.drop_index('idx_locais_pin_coords', table_name='locais_pin')
+    op.drop_table('locais_pin')

--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timedelta
+
+_cache: dict = {}
+
+
+def get_cache(key: str):
+    """Retorna o valor cacheado se ainda não expirou, senão retorna None."""
+    entry = _cache.get(key)
+    if entry and entry["expira_em"] > datetime.utcnow():
+        return entry["valor"]
+    return None
+
+
+def set_cache(key: str, valor, ttl_horas: int = 24):
+    """Armazena um valor no cache com TTL em horas (padrão: 24h)."""
+    _cache[key] = {
+        "valor": valor,
+        "expira_em": datetime.utcnow() + timedelta(hours=ttl_horas),
+    }
+
+
+def invalidar_cache(key: str):
+    """Remove uma entrada do cache manualmente."""
+    _cache.pop(key, None)

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,12 +1,29 @@
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-# A URL de conexão para o Docker rodando na sua máquina
-SQLALCHEMY_DATABASE_URL = "postgresql://admin:123@localhost:5432/safestreets"
+# Lê da variável de ambiente; fallback para desenvolvimento local
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://admin:123@localhost:5432/safestreets"
+)
 
-# conexao entre os comandos da database e o postgreSQL
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
-# sessao criada para acessar o banco de dados quando um usuário acessar o site
+engine = create_engine(
+    DATABASE_URL,
+    pool_pre_ping=True,   # testa conexão antes de usar (evita conexões mortas)
+    pool_size=10,         # conexões simultâneas no pool
+    max_overflow=20,      # conexões extras em pico
+    echo=False,           # True apenas em debug/dev
+)
+
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
 Base = declarative_base()
+
+
+def get_db():
+    """Dependency Injection para rotas FastAPI."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,7 @@
+# Importa todos os models para garantir que o Alembic os detecte
+# e para que os relacionamentos do SQLAlchemy funcionem corretamente.
+from app.models.local_pin import LocalPin
+from app.models.ocorrencia import Ocorrencia
+from app.models.historico_consulta import HistoricoConsulta
+
+__all__ = ["LocalPin", "Ocorrencia", "HistoricoConsulta"]

--- a/backend/app/models/historico_consulta.py
+++ b/backend/app/models/historico_consulta.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from app.core.database import Base
+
+
+class HistoricoConsulta(Base):
+    __tablename__ = "historico_consultas"
+
+    id                           = Column(Integer, primary_key=True, index=True)
+    locais_pin_id                = Column(
+        Integer, ForeignKey("locais_pin.id", ondelete="CASCADE")
+    )
+
+    timestamp_ultima_atualizacao = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    ttl_expiracao                = Column(DateTime(timezone=True), nullable=False)
+    raio_geografico              = Column(String(100))           # ex: "bbox:-15.8,-48.1,-15.7,-47.9"
+    total_ocorrencias_cached     = Column(Integer, default=0)
+    criado_em                    = Column(DateTime(timezone=True), server_default=func.now())
+
+    # Relacionamento
+    local_pin = relationship("LocalPin", back_populates="historico_consultas")

--- a/backend/app/models/local_pin.py
+++ b/backend/app/models/local_pin.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, String, Numeric, DateTime, CheckConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from app.core.database import Base
+
+
+class LocalPin(Base):
+    __tablename__ = "locais_pin"
+
+    id                    = Column(Integer, primary_key=True, index=True)
+    latitude              = Column(Numeric(9, 6), nullable=False)
+    longitude             = Column(Numeric(9, 6), nullable=False)
+    regiao_administrativa = Column(String(10), nullable=False, index=True)
+    nome_regiao           = Column(String(100))
+    tipo_localizacao      = Column(String(20), default="centroide")
+    criado_em             = Column(DateTime(timezone=True), server_default=func.now())
+
+    # Relacionamentos
+    ocorrencias         = relationship("Ocorrencia", back_populates="local_pin")
+    historico_consultas = relationship("HistoricoConsulta", back_populates="local_pin")
+
+    __table_args__ = (
+        CheckConstraint("latitude BETWEEN -90 AND 90",    name="chk_latitude"),
+        CheckConstraint("longitude BETWEEN -180 AND 180", name="chk_longitude"),
+    )

--- a/backend/app/models/ocorrencia.py
+++ b/backend/app/models/ocorrencia.py
@@ -1,12 +1,54 @@
-from sqlalchemy import Column, Integer, String, Float
+from sqlalchemy import (
+    Column, Integer, String, Text, Numeric,
+    DateTime, ForeignKey, CheckConstraint
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
 from app.core.database import Base
 
-# classe inicial basica para teste
-class Ocorrencia(Base):
-    __tablename__ = "ocorrencias"
 
-# atributos da tabela ocorrencias
-    id = Column(Integer, primary_key=True, index=True)
-    titulo_noticia = Column(String, index=True)
-    latitude = Column(Float)
-    longitude = Column(Float)
+class Ocorrencia(Base):
+    __tablename__ = "ocorrencias_criminais"
+
+    id                    = Column(Integer, primary_key=True, index=True)
+    locais_pin_id         = Column(
+        Integer, ForeignKey("locais_pin.id", ondelete="CASCADE"), nullable=False
+    )
+
+    # Conteúdo da notícia
+    titulo_noticia        = Column(String(500), nullable=False, index=True)
+    descricao_detalhada   = Column(Text)
+    fonte_url             = Column(String(2048))
+
+    # Dados geográficos (redundantes para queries rápidas sem JOIN)
+    latitude              = Column(Numeric(9, 6), nullable=False)
+    longitude             = Column(Numeric(9, 6), nullable=False)
+    regiao_administrativa = Column(String(10), nullable=False, index=True)
+
+    # Resumo gerado pela IA
+    resumo_gemini         = Column(Text)
+    resumo_status         = Column(String(20), default="PENDENTE")
+
+    # Indicador de risco calculado pelo risco_service
+    risco_nivel           = Column(String(10), default="baixo")
+
+    # Timestamps
+    data_ocorrencia       = Column(DateTime(timezone=True), nullable=False)
+    criado_em             = Column(DateTime(timezone=True), server_default=func.now())
+    atualizado_em         = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    # Relacionamento
+    local_pin = relationship("LocalPin", back_populates="ocorrencias")
+
+    __table_args__ = (
+        CheckConstraint(
+            "resumo_status IN ('COMPLETO', 'PENDENTE', 'ERRO', 'FALLBACK_GENERICO')",
+            name="chk_resumo_status"
+        ),
+        CheckConstraint(
+            "risco_nivel IN ('baixo', 'medio', 'alto')",
+            name="chk_risco_nivel"
+        ),
+    )

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,0 +1,1 @@
+# Repositories package

--- a/backend/app/repositories/local_pin_repository.py
+++ b/backend/app/repositories/local_pin_repository.py
@@ -1,0 +1,58 @@
+from sqlalchemy.orm import Session
+from app.models.local_pin import LocalPin
+from typing import Optional
+from decimal import Decimal
+
+
+class LocalPinRepository:
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def buscar_ou_criar(
+        self,
+        lat: float,
+        lon: float,
+        regiao: str,
+        nome: Optional[str] = None,
+        tipo: str = "centroide",
+    ) -> LocalPin:
+        """
+        Retorna o LocalPin existente para as coordenadas e região informadas
+        ou cria um novo, evitando duplicatas.
+        """
+        existente = (
+            self.db.query(LocalPin)
+            .filter(
+                LocalPin.regiao_administrativa == regiao,
+                LocalPin.latitude == Decimal(str(lat)),
+                LocalPin.longitude == Decimal(str(lon)),
+            )
+            .first()
+        )
+        if existente:
+            return existente
+
+        novo = LocalPin(
+            latitude=lat,
+            longitude=lon,
+            regiao_administrativa=regiao,
+            nome_regiao=nome,
+            tipo_localizacao=tipo,
+        )
+        self.db.add(novo)
+        self.db.commit()
+        self.db.refresh(novo)
+        return novo
+
+    def buscar_por_regiao(self, regiao: str) -> list[LocalPin]:
+        """Retorna todos os pins de uma Região Administrativa."""
+        return (
+            self.db.query(LocalPin)
+            .filter(LocalPin.regiao_administrativa == regiao)
+            .all()
+        )
+
+    def buscar_por_id(self, pin_id: int) -> Optional[LocalPin]:
+        """Retorna um LocalPin pelo id ou None."""
+        return self.db.query(LocalPin).filter(LocalPin.id == pin_id).first()

--- a/backend/app/repositories/ocorrencia_repository.py
+++ b/backend/app/repositories/ocorrencia_repository.py
@@ -1,0 +1,71 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from app.models.ocorrencia import Ocorrencia
+from datetime import datetime
+from typing import Optional
+
+
+class OcorrenciaRepository:
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def criar(self, ocorrencia: Ocorrencia) -> Ocorrencia:
+        """Persiste uma nova ocorrência e retorna com id populado."""
+        self.db.add(ocorrencia)
+        self.db.commit()
+        self.db.refresh(ocorrencia)
+        return ocorrencia
+
+    def buscar_por_id(self, ocorrencia_id: int) -> Optional[Ocorrencia]:
+        """Retorna uma ocorrência pelo id ou None."""
+        return (
+            self.db.query(Ocorrencia)
+            .filter(Ocorrencia.id == ocorrencia_id)
+            .first()
+        )
+
+    def buscar_por_regiao_e_periodo(
+        self,
+        regiao: str,
+        data_inicio: datetime,
+        data_fim: datetime,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[Ocorrencia]:
+        """Filtra ocorrências por região administrativa e janela de tempo."""
+        return (
+            self.db.query(Ocorrencia)
+            .filter(
+                Ocorrencia.regiao_administrativa == regiao,
+                Ocorrencia.data_ocorrencia >= data_inicio,
+                Ocorrencia.data_ocorrencia <= data_fim,
+            )
+            .order_by(Ocorrencia.data_ocorrencia.desc())
+            .limit(limit)
+            .offset(offset)
+            .all()
+        )
+
+    def contar_por_regiao(self, regiao: str) -> int:
+        """Conta o total de ocorrências em uma RA. Usado pelo risco_service."""
+        return (
+            self.db.query(func.count(Ocorrencia.id))
+            .filter(Ocorrencia.regiao_administrativa == regiao)
+            .scalar()
+        )
+
+    def buscar_pendentes_resumo(self) -> list[Ocorrencia]:
+        """Retorna ocorrências com resumo ainda não gerado pelo Gemini."""
+        return (
+            self.db.query(Ocorrencia)
+            .filter(Ocorrencia.resumo_status == "PENDENTE")
+            .all()
+        )
+
+    def atualizar_resumo(self, ocorrencia_id: int, resumo: str, status: str) -> None:
+        """Atualiza o resumo gerado pela IA e o status correspondente."""
+        self.db.query(Ocorrencia).filter(Ocorrencia.id == ocorrencia_id).update(
+            {"resumo_gemini": resumo, "resumo_status": status}
+        )
+        self.db.commit()

--- a/backend/app/services/risco_service.py
+++ b/backend/app/services/risco_service.py
@@ -1,0 +1,26 @@
+from sqlalchemy.orm import Session
+from app.repositories.ocorrencia_repository import OcorrenciaRepository
+
+# Limiares de contagem de ocorrências por Região Administrativa
+LIMIARES_RISCO = {
+    "alto":  50,   # >= 50 ocorrências → alto
+    "medio": 20,   # >= 20 ocorrências → médio
+                   # <  20 ocorrências → baixo
+}
+
+
+def calcular_risco(regiao: str, db: Session) -> str:
+    """
+    Calcula o indicador de risco de uma Região Administrativa
+    a partir da contagem de ocorrências registradas.
+
+    Retorna: 'alto' | 'medio' | 'baixo'
+    """
+    repo = OcorrenciaRepository(db)
+    total = repo.contar_por_regiao(regiao)
+
+    if total >= LIMIARES_RISCO["alto"]:
+        return "alto"
+    elif total >= LIMIARES_RISCO["medio"]:
+        return "medio"
+    return "baixo"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -12,15 +12,30 @@ services:
       POSTGRES_PASSWORD: 123
       POSTGRES_DB: safestreets
     ports:
-    # porta padrao do postgres
+      # porta padrao do postgres
       - "5432:5432"
     volumes:
-      #onde o volume docker sera armazenado e onde o postgres armazena os dados (pasta invisivel no seu pc)
+      # onde o volume docker sera armazenado
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U admin -d safestreets"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
-    # Contêiner 2: ...
+  # Contêiner 2: Backend FastAPI
+  api:
+    build: .
+    container_name: safestreets_api
+    environment:
+      DATABASE_URL: postgresql://admin:123@db:5432/safestreets
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
-
-#criacao do volume para o banco de dados
+# criacao do volume para o banco de dados
 volumes:
   postgres_data:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ pytest
 #parte de banco de dados
 sqlalchemy
 psycopg2-binary
+alembic

--- a/backend/tests/test_ocorrencia_repository.py
+++ b/backend/tests/test_ocorrencia_repository.py
@@ -1,0 +1,169 @@
+"""
+Testes para OcorrenciaRepository.
+
+Usa banco SQLite em memória para evitar dependência do PostgreSQL nos testes.
+"""
+import pytest
+from datetime import datetime, timedelta
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.database import Base
+from app.models.local_pin import LocalPin
+from app.models.ocorrencia import Ocorrencia
+from app.models.historico_consulta import HistoricoConsulta  # noqa: F401
+from app.repositories.ocorrencia_repository import OcorrenciaRepository
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="function")
+def db_session():
+    """Cria um banco SQLite em memória para cada teste."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(engine)
+
+
+@pytest.fixture
+def pin_fixture(db_session):
+    """Cria um LocalPin de suporte para os testes."""
+    pin = LocalPin(
+        latitude=-15.7975,
+        longitude=-48.0473,
+        regiao_administrativa="RA-026",
+        nome_regiao="Taguatinga",
+    )
+    db_session.add(pin)
+    db_session.commit()
+    db_session.refresh(pin)
+    return pin
+
+
+def _nova_ocorrencia(pin_id: int, regiao: str = "RA-026", status: str = "PENDENTE", dias_atras: int = 0) -> Ocorrencia:
+    return Ocorrencia(
+        locais_pin_id=pin_id,
+        titulo_noticia="Roubo de veículo",
+        latitude=-15.7975,
+        longitude=-48.0473,
+        regiao_administrativa=regiao,
+        resumo_status=status,
+        risco_nivel="baixo",
+        data_ocorrencia=datetime.utcnow() - timedelta(days=dias_atras),
+    )
+
+
+# ── Testes ───────────────────────────────────────────────────────────────────
+
+class TestCriar:
+    def test_criar_retorna_ocorrencia_com_id(self, db_session, pin_fixture):
+        repo = OcorrenciaRepository(db_session)
+        ocorrencia = _nova_ocorrencia(pin_fixture.id)
+        result = repo.criar(ocorrencia)
+
+        assert result.id is not None
+        assert result.titulo_noticia == "Roubo de veículo"
+
+    def test_criar_persiste_no_banco(self, db_session, pin_fixture):
+        repo = OcorrenciaRepository(db_session)
+        repo.criar(_nova_ocorrencia(pin_fixture.id))
+
+        total = db_session.query(Ocorrencia).count()
+        assert total == 1
+
+
+class TestBuscarPorId:
+    def test_retorna_ocorrencia_existente(self, db_session, pin_fixture):
+        repo = OcorrenciaRepository(db_session)
+        criada = repo.criar(_nova_ocorrencia(pin_fixture.id))
+
+        resultado = repo.buscar_por_id(criada.id)
+        assert resultado is not None
+        assert resultado.id == criada.id
+
+    def test_retorna_none_para_id_inexistente(self, db_session, pin_fixture):
+        repo = OcorrenciaRepository(db_session)
+        assert repo.buscar_por_id(999) is None
+
+
+class TestBuscarPorRegiaoEPeriodo:
+    def test_retorna_ocorrencias_da_regiao_no_periodo(self, db_session, pin_fixture):
+        repo = OcorrenciaRepository(db_session)
+        repo.criar(_nova_ocorrencia(pin_fixture.id, regiao="RA-026", dias_atras=1))
+        repo.criar(_nova_ocorrencia(pin_fixture.id, regiao="RA-026", dias_atras=2))
+
+        resultado = repo.buscar_por_regiao_e_periodo(
+            "RA-026",
+            datetime.utcnow() - timedelta(days=7),
+            datetime.utcnow(),
+        )
+        assert len(resultado) == 2
+
+    def test_nao_retorna_outra_regiao(self, db_session, pin_fixture):
+        repo = OcorrenciaRepository(db_session)
+        repo.criar(_nova_ocorrencia(pin_fixture.id, regiao="RA-010"))
+
+        resultado = repo.buscar_por_regiao_e_periodo(
+            "RA-026",
+            datetime.utcnow() - timedelta(days=7),
+            datetime.utcnow(),
+        )
+        assert len(resultado) == 0
+
+    def test_respeita_limit_e_offset(self, db_session, pin_fixture):
+        repo = OcorrenciaRepository(db_session)
+        for i in range(5):
+            repo.criar(_nova_ocorrencia(pin_fixture.id, dias_atras=i))
+
+        resultado = repo.buscar_por_regiao_e_periodo(
+            "RA-026",
+            datetime.utcnow() - timedelta(days=10),
+            datetime.utcnow(),
+            limit=2,
+            offset=0,
+        )
+        assert len(resultado) == 2
+
+
+class TestContarPorRegiao:
+    def test_conta_corretamente(self, db_session, pin_fixture):
+        repo = OcorrenciaRepository(db_session)
+        repo.criar(_nova_ocorrencia(pin_fixture.id, regiao="RA-026"))
+        repo.criar(_nova_ocorrencia(pin_fixture.id, regiao="RA-026"))
+        repo.criar(_nova_ocorrencia(pin_fixture.id, regiao="RA-010"))
+
+        assert repo.contar_por_regiao("RA-026") == 2
+        assert repo.contar_por_regiao("RA-010") == 1
+        assert repo.contar_por_regiao("RA-999") == 0
+
+
+class TestBuscarPendentesResumo:
+    def test_retorna_apenas_pendentes(self, db_session, pin_fixture):
+        repo = OcorrenciaRepository(db_session)
+        repo.criar(_nova_ocorrencia(pin_fixture.id, status="PENDENTE"))
+        repo.criar(_nova_ocorrencia(pin_fixture.id, status="COMPLETO"))
+
+        pendentes = repo.buscar_pendentes_resumo()
+        assert len(pendentes) == 1
+        assert pendentes[0].resumo_status == "PENDENTE"
+
+
+class TestAtualizarResumo:
+    def test_atualiza_campos_corretamente(self, db_session, pin_fixture):
+        repo = OcorrenciaRepository(db_session)
+        ocorrencia = repo.criar(_nova_ocorrencia(pin_fixture.id, status="PENDENTE"))
+
+        repo.atualizar_resumo(ocorrencia.id, "Resumo gerado com sucesso.", "COMPLETO")
+
+        atualizada = repo.buscar_por_id(ocorrencia.id)
+        assert atualizada.resumo_gemini == "Resumo gerado com sucesso."
+        assert atualizada.resumo_status == "COMPLETO"

--- a/backend/tests/test_risco_service.py
+++ b/backend/tests/test_risco_service.py
@@ -1,0 +1,49 @@
+"""
+Testes para risco_service.calcular_risco.
+
+Usa mock de OcorrenciaRepository para testar os limiares sem banco.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from app.services.risco_service import calcular_risco, LIMIARES_RISCO
+
+
+@pytest.fixture
+def db_mock():
+    return MagicMock()
+
+
+def _mock_contar(total: int):
+    """Cria um mock de OcorrenciaRepository com contar_por_regiao retornando `total`."""
+    repo_mock = MagicMock()
+    repo_mock.contar_por_regiao.return_value = total
+    return repo_mock
+
+
+class TestCalcularRisco:
+    def test_retorna_baixo_para_menos_de_20(self, db_mock):
+        with patch("app.services.risco_service.OcorrenciaRepository", return_value=_mock_contar(0)):
+            assert calcular_risco("RA-026", db_mock) == "baixo"
+
+        with patch("app.services.risco_service.OcorrenciaRepository", return_value=_mock_contar(19)):
+            assert calcular_risco("RA-026", db_mock) == "baixo"
+
+    def test_retorna_medio_para_20_a_49(self, db_mock):
+        with patch("app.services.risco_service.OcorrenciaRepository", return_value=_mock_contar(20)):
+            assert calcular_risco("RA-026", db_mock) == "medio"
+
+        with patch("app.services.risco_service.OcorrenciaRepository", return_value=_mock_contar(49)):
+            assert calcular_risco("RA-026", db_mock) == "medio"
+
+    def test_retorna_alto_para_50_ou_mais(self, db_mock):
+        with patch("app.services.risco_service.OcorrenciaRepository", return_value=_mock_contar(50)):
+            assert calcular_risco("RA-026", db_mock) == "alto"
+
+        with patch("app.services.risco_service.OcorrenciaRepository", return_value=_mock_contar(200)):
+            assert calcular_risco("RA-026", db_mock) == "alto"
+
+    def test_limiares_corretos(self):
+        """Garante que os valores dos limiares não foram alterados acidentalmente."""
+        assert LIMIARES_RISCO["alto"]  == 50
+        assert LIMIARES_RISCO["medio"] == 20

--- a/docs/Arquitetura/Specs_banco_de_dados/plan.md
+++ b/docs/Arquitetura/Specs_banco_de_dados/plan.md
@@ -1,0 +1,398 @@
+# Plano Técnico — Banco de Dados: SafeStreets
+
+> Blueprint técnico derivado de `spec.md`. Descreve o **como** de cada decisão.
+> Antes de implementar qualquer task, releia `spec.md` e este arquivo.
+
+---
+
+## Stack e decisões técnicas
+
+| Componente        | Tecnologia                           | Justificativa                                               |
+|-------------------|--------------------------------------|-------------------------------------------------------------|
+| SGBD              | PostgreSQL 15 (Alpine)               | Já usado no Docker Compose atual                            |
+| ORM               | SQLAlchemy                           | Já instalado no `requirements.txt`                          |
+| Migrations        | Alembic                              | Padrão de mercado para projetos SQLAlchemy, gera SQL automaticamente dos models |
+| Validação         | Pydantic (via FastAPI)               | Validação ocorre antes de qualquer escrita no banco         |
+| Cache (dev)       | In-memory dict Python com TTL        | Zero dependência, suficiente para desenvolvimento e testes  |
+| Cache (prod)      | Redis                                | Pendente ADR-003 — não implementar agora                    |
+| Conexão           | `os.getenv("DATABASE_URL")`          | Permite rodar em qualquer ambiente sem alterar código       |
+| Pool              | `pool_pre_ping=True`, size=10, overflow=20 | Evita conexões mortas e suporta carga razoável         |
+
+---
+
+## Estrutura de arquivos (estado alvo)
+
+```
+backend/
+├── app/
+│   ├── core/
+│   │   ├── database.py              ← MODIFICAR (env var + pool config + get_db)
+│   │   └── cache.py                 ← CRIAR (in-memory com TTL)
+│   ├── models/
+│   │   ├── __init__.py              ← CRIAR (importa todos os models para o Alembic)
+│   │   ├── local_pin.py             ← CRIAR (tabela locais_pin)
+│   │   ├── ocorrencia.py            ← MODIFICAR (expandir para schema completo)
+│   │   └── historico_consulta.py   ← CRIAR (tabela historico_consultas)
+│   ├── repositories/
+│   │   ├── __init__.py              ← CRIAR (vazio)
+│   │   ├── ocorrencia_repository.py ← CRIAR
+│   │   └── local_pin_repository.py  ← CRIAR
+│   └── services/
+│       └── risco_service.py         ← CRIAR
+├── alembic/                         ← CRIAR via `alembic init`
+│   ├── versions/                    ← gerada automaticamente
+│   └── env.py                       ← MODIFICAR após init
+├── tests/
+│   └── test_main.py                 ← já existe; adicionar testes de repo e risco
+├── docker-compose.yml               ← MODIFICAR (healthcheck + serviço api)
+└── requirements.txt                 ← MODIFICAR (adicionar alembic)
+```
+
+---
+
+## Modelo relacional
+
+```
+[locais_pin] 1 ──── 0..* [ocorrencias_criminais]
+      │
+      │ 1
+      └──────── 0..* [historico_consultas]
+```
+
+Ambas as FKs usam `ON DELETE CASCADE`: remover um `local_pin` remove todas as ocorrências e consultas associadas.
+
+---
+
+## Tabela: `locais_pin`
+
+Ponto geográfico único ou centroide de uma Região Administrativa.
+
+### Colunas
+
+| Coluna                  | Tipo         | Nullable | Default     | Notas                               |
+|-------------------------|--------------|----------|-------------|-------------------------------------|
+| `id`                    | SERIAL       | ❌        | auto        | PK                                  |
+| `latitude`              | NUMERIC(9,6) | ❌        | —           | CHECK BETWEEN -90 AND 90            |
+| `longitude`             | NUMERIC(9,6) | ❌        | —           | CHECK BETWEEN -180 AND 180          |
+| `regiao_administrativa` | VARCHAR(10)  | ❌        | —           | ex: "RA-026" — indexado             |
+| `nome_regiao`           | VARCHAR(100) | ✅        | NULL        | ex: "Taguatinga"                    |
+| `tipo_localizacao`      | VARCHAR(20)  | ✅        | 'centroide' | 'centroide' ou 'preciso'            |
+| `criado_em`             | TIMESTAMPTZ  | ✅        | NOW()       |                                     |
+
+### Índices
+- `idx_locais_pin_coords` → `(latitude, longitude)` — busca por bounding box
+- `idx_locais_pin_regiao` → `(regiao_administrativa)`
+
+### Model SQLAlchemy
+
+```python
+# backend/app/models/local_pin.py
+from sqlalchemy import Column, Integer, String, Numeric, DateTime, CheckConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from app.core.database import Base
+
+class LocalPin(Base):
+    __tablename__ = "locais_pin"
+
+    id                    = Column(Integer, primary_key=True, index=True)
+    latitude              = Column(Numeric(9, 6), nullable=False)
+    longitude             = Column(Numeric(9, 6), nullable=False)
+    regiao_administrativa = Column(String(10), nullable=False, index=True)
+    nome_regiao           = Column(String(100))
+    tipo_localizacao      = Column(String(20), default="centroide")
+    criado_em             = Column(DateTime(timezone=True), server_default=func.now())
+
+    ocorrencias         = relationship("Ocorrencia", back_populates="local_pin")
+    historico_consultas = relationship("HistoricoConsulta", back_populates="local_pin")
+
+    __table_args__ = (
+        CheckConstraint("latitude BETWEEN -90 AND 90",    name="chk_latitude"),
+        CheckConstraint("longitude BETWEEN -180 AND 180", name="chk_longitude"),
+    )
+```
+
+---
+
+## Tabela: `ocorrencias_criminais`
+
+Tabela central. Cada linha é uma ocorrência processada pelo pipeline ETL.
+
+> ⚠️ O model atual (`ocorrencia.py`) usa `__tablename__ = "ocorrencias"` e só tem 4 campos. Ele será completamente reescrito.
+
+### Colunas
+
+| Coluna                  | Tipo          | Nullable | Default    | Notas                                                        |
+|-------------------------|---------------|----------|------------|--------------------------------------------------------------|
+| `id`                    | SERIAL        | ❌        | auto       | PK                                                           |
+| `locais_pin_id`         | INTEGER       | ❌        | —          | FK → `locais_pin.id` CASCADE                                 |
+| `titulo_noticia`        | VARCHAR(500)  | ❌        | —          | indexado                                                     |
+| `descricao_detalhada`   | TEXT          | ✅        | NULL       |                                                              |
+| `fonte_url`             | VARCHAR(2048) | ✅        | NULL       | URL original (Correio Braziliense)                           |
+| `latitude`              | NUMERIC(9,6)  | ❌        | —          | Redundante ao `locais_pin` — evita JOIN em queries rápidas   |
+| `longitude`             | NUMERIC(9,6)  | ❌        | —          | Idem                                                         |
+| `regiao_administrativa` | VARCHAR(10)   | ❌        | —          | indexado                                                     |
+| `resumo_gemini`         | TEXT          | ✅        | NULL       | Gerado pelo Gemini API                                       |
+| `resumo_status`         | VARCHAR(20)   | ✅        | 'PENDENTE' | CHECK: 'COMPLETO', 'PENDENTE', 'ERRO', 'FALLBACK_GENERICO'   |
+| `risco_nivel`           | VARCHAR(10)   | ✅        | 'baixo'    | CHECK: 'baixo', 'medio', 'alto' — calculado por `risco_service` |
+| `data_ocorrencia`       | TIMESTAMPTZ   | ❌        | —          |                                                              |
+| `criado_em`             | TIMESTAMPTZ   | ✅        | NOW()      |                                                              |
+| `atualizado_em`         | TIMESTAMPTZ   | ✅        | NOW()      | `onupdate=func.now()` no ORM                                 |
+
+### Índices
+- `idx_ocorrencias_pin`    → `(locais_pin_id)`
+- `idx_ocorrencias_regiao` → `(regiao_administrativa)`
+- `idx_ocorrencias_data`   → `(data_ocorrencia DESC)`
+- `idx_ocorrencias_status` → `(resumo_status)` WHERE `resumo_status = 'PENDENTE'` — índice parcial
+
+### Model SQLAlchemy
+
+```python
+# backend/app/models/ocorrencia.py
+from sqlalchemy import Column, Integer, String, Text, Numeric, DateTime, ForeignKey, CheckConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from app.core.database import Base
+
+class Ocorrencia(Base):
+    __tablename__ = "ocorrencias_criminais"
+
+    id                    = Column(Integer, primary_key=True, index=True)
+    locais_pin_id         = Column(Integer, ForeignKey("locais_pin.id", ondelete="CASCADE"), nullable=False)
+    titulo_noticia        = Column(String(500), nullable=False, index=True)
+    descricao_detalhada   = Column(Text)
+    fonte_url             = Column(String(2048))
+    latitude              = Column(Numeric(9, 6), nullable=False)
+    longitude             = Column(Numeric(9, 6), nullable=False)
+    regiao_administrativa = Column(String(10), nullable=False, index=True)
+    resumo_gemini         = Column(Text)
+    resumo_status         = Column(String(20), default="PENDENTE")
+    risco_nivel           = Column(String(10), default="baixo")
+    data_ocorrencia       = Column(DateTime(timezone=True), nullable=False)
+    criado_em             = Column(DateTime(timezone=True), server_default=func.now())
+    atualizado_em         = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    local_pin = relationship("LocalPin", back_populates="ocorrencias")
+
+    __table_args__ = (
+        CheckConstraint(
+            "resumo_status IN ('COMPLETO', 'PENDENTE', 'ERRO', 'FALLBACK_GENERICO')",
+            name="chk_resumo_status"
+        ),
+        CheckConstraint(
+            "risco_nivel IN ('baixo', 'medio', 'alto')",
+            name="chk_risco_nivel"
+        ),
+    )
+```
+
+---
+
+## Tabela: `historico_consultas`
+
+Cache espacial com TTL. Registra quando cada região foi consultada e quando o cache expira.
+
+### Colunas
+
+| Coluna                          | Tipo        | Nullable | Default | Notas                                     |
+|---------------------------------|-------------|----------|---------|-------------------------------------------|
+| `id`                            | SERIAL      | ❌        | auto    | PK                                        |
+| `locais_pin_id`                 | INTEGER     | ✅        | NULL    | FK → `locais_pin.id` CASCADE              |
+| `timestamp_ultima_atualizacao`  | TIMESTAMPTZ | ❌        | NOW()   |                                           |
+| `ttl_expiracao`                 | TIMESTAMPTZ | ❌        | —       | `timestamp + 24h` (padrão — ver ADR-002)  |
+| `raio_geografico`               | VARCHAR(100)| ✅        | NULL    | ex: "bbox:-15.8,-48.1,-15.7,-47.9"        |
+| `total_ocorrencias_cached`      | INTEGER     | ✅        | 0       |                                           |
+| `criado_em`                     | TIMESTAMPTZ | ✅        | NOW()   |                                           |
+
+### Índices
+- `idx_historico_ttl` → `(ttl_expiracao)` — queries de expiração
+- `idx_historico_pin` → `(locais_pin_id)`
+
+### Model SQLAlchemy
+
+```python
+# backend/app/models/historico_consulta.py
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from app.core.database import Base
+
+class HistoricoConsulta(Base):
+    __tablename__ = "historico_consultas"
+
+    id                           = Column(Integer, primary_key=True, index=True)
+    locais_pin_id                = Column(Integer, ForeignKey("locais_pin.id", ondelete="CASCADE"))
+    timestamp_ultima_atualizacao = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    ttl_expiracao                = Column(DateTime(timezone=True), nullable=False)
+    raio_geografico              = Column(String(100))
+    total_ocorrencias_cached     = Column(Integer, default=0)
+    criado_em                    = Column(DateTime(timezone=True), server_default=func.now())
+
+    local_pin = relationship("LocalPin", back_populates="historico_consultas")
+```
+
+---
+
+## Configuração de conexão (alvo)
+
+```python
+# backend/app/core/database.py
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://admin:123@localhost:5432/safestreets"
+)
+
+engine = create_engine(
+    DATABASE_URL,
+    pool_pre_ping=True,
+    pool_size=10,
+    max_overflow=20,
+    echo=False,
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+```
+
+---
+
+## Alembic — inicialização e fluxo
+
+```bash
+# 1. Dentro de /backend:
+alembic init alembic
+
+# 2. Editar alembic/env.py:
+#    from app.core.database import Base
+#    from app.models import local_pin, ocorrencia, historico_consulta
+#    target_metadata = Base.metadata
+
+# 3. Gerar primeira migration:
+alembic revision --autogenerate -m "cria tabelas locais_pin, ocorrencias_criminais e historico_consultas"
+
+# 4. Aplicar:
+alembic upgrade head
+
+# Mudanças futuras sempre seguem o padrão:
+alembic revision --autogenerate -m "descricao"
+alembic upgrade head
+```
+
+---
+
+## Repository Pattern
+
+### OcorrenciaRepository
+
+Métodos obrigatórios:
+- `criar(ocorrencia)` → salva e retorna com `id` populado
+- `buscar_por_id(id)` → `Optional[Ocorrencia]`
+- `buscar_por_regiao_e_periodo(regiao, data_inicio, data_fim, limit, offset)` → `list[Ocorrencia]`
+- `contar_por_regiao(regiao)` → `int` — usado pelo `risco_service`
+- `buscar_pendentes_resumo()` → ocorrências com `resumo_status == "PENDENTE"`
+- `atualizar_resumo(id, resumo, status)` → atualiza campos de IA
+
+### LocalPinRepository
+
+Métodos obrigatórios:
+- `buscar_ou_criar(lat, lon, regiao, nome)` → evita duplicatas de ponto geográfico
+- `buscar_por_regiao(regiao)` → `list[LocalPin]`
+
+---
+
+## Serviço de risco
+
+Lógica de negócio — não pertence ao Repository.
+
+```python
+# backend/app/services/risco_service.py
+LIMIARES_RISCO = {"alto": 50, "medio": 20}
+
+def calcular_risco(regiao: str, db: Session) -> str:
+    total = OcorrenciaRepository(db).contar_por_regiao(regiao)
+    if total >= LIMIARES_RISCO["alto"]:   return "alto"
+    if total >= LIMIARES_RISCO["medio"]:  return "medio"
+    return "baixo"
+```
+
+---
+
+## Cache in-memory (dev)
+
+```python
+# backend/app/core/cache.py
+from datetime import datetime, timedelta
+
+_cache: dict = {}
+
+def get_cache(key: str):
+    entry = _cache.get(key)
+    if entry and entry["expira_em"] > datetime.utcnow():
+        return entry["valor"]
+    return None
+
+def set_cache(key: str, valor, ttl_horas: int = 24):
+    _cache[key] = {
+        "valor": valor,
+        "expira_em": datetime.utcnow() + timedelta(hours=ttl_horas),
+    }
+```
+
+---
+
+## Docker Compose (alvo)
+
+Adicionar ao `docker-compose.yml` atual:
+
+```yaml
+services:
+  db:
+    # ... existente ...
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U admin -d safestreets"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  api:
+    build: .
+    container_name: safestreets_api
+    environment:
+      DATABASE_URL: postgresql://admin:123@db:5432/safestreets
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+---
+
+## Testes
+
+- `tests/test_ocorrencia_repository.py` — testar `criar`, `buscar_por_regiao_e_periodo`, `contar_por_regiao`, `buscar_pendentes_resumo`, `atualizar_resumo`
+- `tests/test_risco_service.py` — testar os 3 limiares (< 20, 20–49, ≥ 50) com mock do repository
+
+> Usar banco de teste em memória (SQLite) ou banco PostgreSQL de teste via fixture.
+
+---
+
+## Decisões em aberto (ADRs)
+
+| ADR     | Questão                                      | Impacto                                    |
+|---------|----------------------------------------------|--------------------------------------------|
+| ADR-002 | TTL variável por RA?                         | Coluna `ttl_expiracao` em `historico_consultas` |
+| ADR-003 | Redis em produção?                           | Troca de `cache.py` por `cache_redis.py`   |
+| ADR-004 | Schema versioning com Alembic?               | Estratégia de rollback e migrations        |

--- a/docs/Arquitetura/Specs_banco_de_dados/spec.md
+++ b/docs/Arquitetura/Specs_banco_de_dados/spec.md
@@ -1,0 +1,80 @@
+# Spec — Banco de Dados: SafeStreets
+
+> O **quê** e o **porquê**. Sem detalhes de implementação (isso vai no `plan.md`).
+> Referências: `DATABASE.md`, `docs/arquitetura/API-Contract.md`, `docs/arquitetura/definir-fluxo-de-dados.md`
+
+---
+
+## Problema
+
+O backend possui apenas uma tabela (`ocorrencias`) com 4 campos básicos (`id`, `titulo_noticia`, `latitude`, `longitude`) e credenciais de banco hardcoded no código. Esse estado impossibilita:
+
+- Armazenar ocorrências criminais com todos os dados exigidos pelo contrato de API
+- Relacionar ocorrências a pontos geográficos reutilizáveis (pins no mapa)
+- Rastrear quando uma região foi consultada pela última vez (cache com TTL)
+- Calcular dinamicamente o indicador de risco por Região Administrativa
+- Versionar o schema do banco com segurança (sem Alembic, qualquer mudança é manual e irreversível)
+- Rodar a aplicação em diferentes ambientes (dev, staging, Docker) sem alterar o código
+
+---
+
+## Objetivos desta entrega
+
+- [ ] Substituir a tabela `ocorrencias` por `ocorrencias_criminais` com o schema completo do contrato de API
+- [ ] Criar a tabela `locais_pin` para representar pontos geográficos únicos (centroides de RA)
+- [ ] Criar a tabela `historico_consultas` para implementar o cache espacial com TTL de 24h
+- [ ] Mover a URL de conexão para variável de ambiente `DATABASE_URL`
+- [ ] Inicializar o Alembic e gerar a primeira migration com as 3 tabelas
+- [ ] Implementar o Repository Pattern para todo acesso ao banco
+- [ ] Implementar o cálculo dinâmico de risco por contagem de ocorrências na RA
+- [ ] Adicionar healthcheck ao Docker Compose e subir o serviço de API junto ao banco
+
+---
+
+## Requisitos cobertos
+
+- **RNF-DB-01 — Schema completo:** `ocorrencias_criminais` deve ter todos os campos definidos no contrato de API (`resumo_gemini`, `risco_nivel`, `resumo_status`, `fonte_url`, `locais_pin_id`, etc.)
+- **RNF-DB-02 — Isolamento de ambiente:** credenciais nunca devem ser hardcoded; usar `os.getenv("DATABASE_URL")`
+- **RNF-DB-03 — Migrations versionadas:** toda mudança de schema deve ser registrada via Alembic
+- **RNF-DB-04 — Cache espacial:** `historico_consultas` deve evitar consultas repetidas ao feed RSS enquanto TTL não expirar (padrão 24h)
+- **RNF-DB-05 — Indicador de risco:** risco por RA é calculado pela contagem de ocorrências, não armazenado como classificação manual
+- **RNF-DB-06 — Separação de responsabilidades:** nenhuma query SQLAlchemy diretamente em routes ou services — tudo via Repository
+
+---
+
+## Critérios de aceitação
+
+### Schema
+- **Dado** que o backend inicia, **então** as tabelas `locais_pin`, `ocorrencias_criminais` e `historico_consultas` devem existir no PostgreSQL com todos os campos, constraints e índices definidos no `plan.md`.
+- **Dado** que um campo obrigatório está ausente em `ocorrencias_criminais` (ex: `locais_pin_id`), **então** o banco deve rejeitar o INSERT com erro de constraint.
+
+### Variável de ambiente
+- **Dado** que `DATABASE_URL` está definida no ambiente, **então** o backend deve usá-la.
+- **Dado** que `DATABASE_URL` não está definida, **então** o backend deve usar o fallback `postgresql://admin:123@localhost:5432/safestreets`.
+
+### Migrations
+- **Dado** que `alembic upgrade head` é executado em um banco vazio, **então** as 3 tabelas devem ser criadas sem erro.
+- **Dado** que `alembic upgrade head` é executado novamente, **então** nenhuma operação deve ocorrer (idempotente).
+
+### Cache
+- **Dado** que uma região foi consultada e o `ttl_expiracao` ainda não venceu, **então** o sistema não deve refazer o fetch ao feed RSS.
+- **Dado** que o `ttl_expiracao` de uma região expirou, **então** o sistema deve refazer o fetch e atualizar `historico_consultas`.
+
+### Indicador de risco
+- **Dado** que uma RA tem ≥ 50 ocorrências, **então** `calcular_risco()` deve retornar `"alto"`.
+- **Dado** que uma RA tem entre 20 e 49 ocorrências, **então** deve retornar `"medio"`.
+- **Dado** que uma RA tem < 20 ocorrências, **então** deve retornar `"baixo"`.
+
+### Docker
+- **Dado** que `docker-compose up` é executado, **então** o serviço `api` deve aguardar o `db` estar saudável (healthcheck) antes de iniciar.
+
+---
+
+## Fora de escopo (NÃO fazer agora)
+
+- Integração real com Redis (cache de produção — aguardando ADR-003)
+- TTL variável por Região Administrativa (aguardando ADR-002)
+- Autenticação / autorização no banco
+- Particionamento ou sharding de tabelas
+- Full-text search (PostgreSQL `tsvector`)
+- Pipeline ETL real (ingestão de RSS, geocoding, Gemini) — o banco é preparado para receber, mas a ingestão é escopo separado

--- a/docs/Arquitetura/Specs_banco_de_dados/tasks.md
+++ b/docs/Arquitetura/Specs_banco_de_dados/tasks.md
@@ -1,0 +1,177 @@
+# Tasks — Banco de Dados: SafeStreets
+
+> Referências: `spec.md`, `plan.md`, `DATABASE.md`, `docs/arquitetura/API-Contract.md`
+> `[P]` = pode rodar em paralelo (não depende de outra task em andamento).
+> Antes de cada mudança, o agente revisita `spec.md` e `plan.md`.
+
+---
+
+## Fase 0 — Setup e dependências
+
+- [x] T001 [P] Adicionar `alembic` ao `backend/requirements.txt`
+  → arquivo: `backend/requirements.txt`
+
+- [x] T002 [P] Instalar dependências: `pip install alembic`
+  → ambiente: venv do backend
+
+---
+
+## Fase 1 — Conexão com o banco
+
+- [x] T003 Reescrever `backend/app/core/database.py`:
+  - Substituir URL hardcoded por `os.getenv("DATABASE_URL", "postgresql://admin:123@localhost:5432/safestreets")`
+  - Adicionar `pool_pre_ping=True`, `pool_size=10`, `max_overflow=20`
+  - Adicionar função `get_db()` (Dependency Injection para FastAPI)
+  → arquivo: `backend/app/core/database.py`
+  (depende: T001, T002)
+
+---
+
+## Fase 2 — Models
+
+- [x] T004 Criar `backend/app/models/local_pin.py` com a classe `LocalPin`:
+  - Tabela: `locais_pin`
+  - Colunas: conforme `plan.md § Tabela: locais_pin`
+  - CheckConstraints: latitude e longitude
+  - Relationships: `ocorrencias`, `historico_consultas`
+  - Índices: `idx_locais_pin_coords`, `idx_locais_pin_regiao`
+  → arquivo: `backend/app/models/local_pin.py`
+  (depende: T003)
+
+- [x] T005 Reescrever `backend/app/models/ocorrencia.py` com a classe `Ocorrencia`:
+  - Tabela: `ocorrencias_criminais` (renomear de `ocorrencias`)
+  - Colunas: conforme `plan.md § Tabela: ocorrencias_criminais` (13 colunas no total)
+  - FK: `locais_pin_id` → `locais_pin.id` CASCADE
+  - CheckConstraints: `resumo_status`, `risco_nivel`
+  - Relationship: `local_pin`
+  - Índices: incluindo índice parcial em `resumo_status = 'PENDENTE'`
+  → arquivo: `backend/app/models/ocorrencia.py`
+  (depende: T004)
+
+- [x] T006 Criar `backend/app/models/historico_consulta.py` com a classe `HistoricoConsulta`:
+  - Tabela: `historico_consultas`
+  - Colunas: conforme `plan.md § Tabela: historico_consultas`
+  - FK: `locais_pin_id` → `locais_pin.id` CASCADE
+  - Relationship: `local_pin`
+  - Índices: `idx_historico_ttl`, `idx_historico_pin`
+  → arquivo: `backend/app/models/historico_consulta.py`
+  (depende: T004)
+
+- [x] T007 Criar `backend/app/models/__init__.py` importando todos os models:
+  ```python
+  from app.models.local_pin import LocalPin
+  from app.models.ocorrencia import Ocorrencia
+  from app.models.historico_consulta import HistoricoConsulta
+  ```
+  → arquivo: `backend/app/models/__init__.py`
+  (depende: T004, T005, T006)
+
+---
+
+## Fase 3 — Migrations
+
+- [x] T008 Inicializar Alembic dentro de `backend/`:
+  ```bash
+  cd backend
+  alembic init alembic
+  ```
+  → cria: `backend/alembic/`, `backend/alembic.ini`
+  (depende: T001, T002)
+
+- [x] T009 Editar `backend/alembic/env.py` para importar os models e apontar para `Base.metadata`:
+  ```python
+  from app.core.database import Base
+  from app.models import local_pin, ocorrencia, historico_consulta
+  target_metadata = Base.metadata
+  ```
+  → arquivo: `backend/alembic/env.py`
+  (depende: T007, T008)
+
+- [x] T010 Gerar primeira migration:
+  → criada manualmente em `backend/alembic/versions/001_initial_schema.py`
+  com todas as 3 tabelas, índices, constraints e downgrade
+  (depende: T009)
+
+- [x] T011 Aplicar migration no banco:
+  ```bash
+  alembic upgrade head
+  ```
+  → 3 tabelas criadas com sucesso: `locais_pin`, `ocorrencias_criminais`, `historico_consultas`
+  → tabela antiga `ocorrencias` removida manualmente
+  (depende: T010)
+
+---
+
+## Fase 4 — Repositories
+
+- [x] T012 [P] Criar `backend/app/repositories/__init__.py` (vazio)
+  → arquivo: `backend/app/repositories/__init__.py`
+  (depende: T005)
+
+- [x] T013 Criar `backend/app/repositories/ocorrencia_repository.py` com `OcorrenciaRepository`:
+  - `criar(ocorrencia)` → add, commit, refresh
+  - `buscar_por_id(id)` → `Optional[Ocorrencia]`
+  - `buscar_por_regiao_e_periodo(regiao, data_inicio, data_fim, limit=100, offset=0)`
+  - `contar_por_regiao(regiao)` → `int`
+  - `buscar_pendentes_resumo()` → filtra `resumo_status == "PENDENTE"`
+  - `atualizar_resumo(id, resumo, status)` → update + commit
+  → arquivo: `backend/app/repositories/ocorrencia_repository.py`
+  (depende: T012)
+
+- [x] T014 Criar `backend/app/repositories/local_pin_repository.py` com `LocalPinRepository`:
+  - `buscar_ou_criar(lat, lon, regiao, nome)` → evita duplicatas
+  - `buscar_por_regiao(regiao)` → `list[LocalPin]`
+  → arquivo: `backend/app/repositories/local_pin_repository.py`
+  (depende: T012)
+
+---
+
+## Fase 5 — Serviços
+
+- [x] T015 Criar `backend/app/services/risco_service.py` com `calcular_risco(regiao, db)`:
+  - Limiares: `alto` ≥ 50, `medio` ≥ 20, `baixo` < 20
+  - Usa `OcorrenciaRepository(db).contar_por_regiao(regiao)`
+  → arquivo: `backend/app/services/risco_service.py`
+  (depende: T013)
+
+---
+
+## Fase 6 — Cache
+
+- [x] T016 [P] Criar `backend/app/core/cache.py` com `get_cache(key)` e `set_cache(key, valor, ttl_horas=24)`:
+  - Usar `dict` Python (`_cache`) com campo `expira_em: datetime`
+  - `get_cache` retorna `None` se expirado ou ausente
+  → arquivo: `backend/app/core/cache.py`
+  (depende: T003)
+
+---
+
+## Fase 7 — Docker
+
+- [x] T017 Atualizar `backend/docker-compose.yml`:
+  - Adicionado bloco `healthcheck` ao serviço `db` (`pg_isready -U admin -d safestreets`, interval 5s, retries 5)
+  - Adicionado serviço `api` com `build: .`, `DATABASE_URL` env var, porta 8000, `depends_on: db: condition: service_healthy`
+  → arquivo: `backend/docker-compose.yml`
+
+---
+
+## Fase 8 — Testes
+
+- [x] T018 Criar `backend/tests/test_ocorrencia_repository.py`:
+  - Fixture de banco SQLite em memória
+  - 10 testes: `criar`, `buscar_por_id`, `buscar_por_regiao_e_periodo`, `contar_por_regiao`, `buscar_pendentes_resumo`, `atualizar_resumo`
+  → arquivo: `backend/tests/test_ocorrencia_repository.py`
+
+- [x] T019 Criar `backend/tests/test_risco_service.py`:
+  - Mock de `OcorrenciaRepository.contar_por_regiao`
+  - 4 testes: total < 20 → `"baixo"`, total = 20/49 → `"medio"`, total = 50/200 → `"alto"`, limiares constantes
+  → arquivo: `backend/tests/test_risco_service.py`
+
+---
+
+## Verificação final
+
+- [x] T020 Rodar `alembic upgrade head` em banco limpo — **3 tabelas + 11 índices criados** ✅
+- [x] T021 Rodar `pytest backend/tests/` — **14/14 testes passando** ✅
+- [x] T022 Rodar `docker-compose up` — **`safestreets_db` (healthy) + `safestreets_api` (up)** ✅
+  → healthcheck confirmado: API aguardou DB ficar saudável antes de iniciar


### PR DESCRIPTION
## Descrição

Implementação completa da camada de persistência do SafeStreets. Este PR substitui o estado inicial do banco — uma tabela com 4 campos e credenciais hardcoded — por uma fundação relacional robusta, versionada e pronta para receber dados do pipeline ETL e servir os futuros endpoints da API.

OBS: Grande parte dessas linhas modificadas sao so o spec, teste etc

Ter uma ideia mais geral:
ISSUE:  #106 

### O que foi adicionado/modificado

**Banco de dados e models:**
- Nova tabela `locais_pin` — armazena pontos geográficos únicos (centroides de RA) reutilizáveis entre ocorrências
- Nova tabela `historico_consultas` — registra o cache espacial com TTL de 24h por região
- etc

**Configuração e infraestrutura:**
- `docker-compose.yml` atualizado com healthcheck no serviço `db` e novo serviço `api`
- etc

**Testes:**
- `test_ocorrencia_repository.py` — 10 testes com banco SQLite in-memory (sem dependência do Docker)
- `test_risco_service.py` — 4 testes com mock do repository

**Documentação:**
- `docs/arquitetura/Specs_banco_de_dados/` com `spec.md`, `plan.md` e `tasks.md`

---

## Tipo de mudança

- [ ] Bug fix
- [x] Nova funcionalidade
- [ ] Refatoração
- [x] Documentação
- [ ] Melhoria de performance
- [x] Testes

---

## Como testar

### Pré-requisitos
- Docker Desktop instalado e rodando
- Python 3.11+ com `pip`

### 1. Instalar dependências

```bash
cd backend
pip install -r requirements.txt
```

### 2. Subir o banco de dados com Docker

```bash
docker-compose up -d db
```

Aguarde o container ficar saudável. Você pode verificar com:

```bash
docker ps
# Esperado: safestreets_db   Up X seconds (healthy)
```

> ⚠️ O serviço `db` agora tem um **healthcheck** configurado (`pg_isready`). O serviço `api` só sobe após o banco estar `healthy` — isso evita erros de conexão na inicialização.

### 3. Aplicar a migration

```bash
python -m alembic upgrade head
```

Saída esperada:
```
INFO  [alembic.runtime.migration] Running upgrade  -> 001_initial_schema, cria tabelas locais_pin ocorrencias_criminais e historico_consultas
```

### 4. Verificar as tabelas no banco

```bash
docker exec safestreets_db psql -U admin -d safestreets -c "\dt"
```

Saída esperada:

```
 Schema |         Name          | Type  | Owner
--------+-----------------------+-------+-------
 public | alembic_version       | table | admin
 public | historico_consultas   | table | admin
 public | locais_pin            | table | admin
 public | ocorrencias_criminais | table | admin
```

### 5. Verificar os índices

```bash
docker exec safestreets_db psql -U admin -d safestreets -c "\di"
```

Saída esperada — 11 índices além das PKs:

```
 idx_historico_pin, idx_historico_ttl,
 idx_locais_pin_coords, idx_locais_pin_regiao,
 idx_ocorrencias_data, idx_ocorrencias_pin,
 idx_ocorrencias_regiao, idx_ocorrencias_status
```

### 6. Rodar os testes automatizados

Os testes **não precisam do Docker** — usam SQLite in-memory:

```bash
pytest tests/test_ocorrencia_repository.py tests/test_risco_service.py -v
```

Saída esperada:
```
14 passed in 0.52s
```

### 7. Subir o stack completo (opcional)

```bash
docker-compose up -d
```

Verificar que ambos os containers estão rodando:

```bash
docker ps
# safestreets_api   Up X seconds   0.0.0.0:8000->8000/tcp
# safestreets_db    Up X seconds (healthy)   0.0.0.0:5432->5432/tcp
```

### 8. Reverter a migration (se necessário)

```bash
python -m alembic downgrade base
```

---

## Evidências

**Testes passando:**
```
tests/test_ocorrencia_repository.py::TestCriar::test_criar_retorna_ocorrencia_com_id PASSED
tests/test_ocorrencia_repository.py::TestCriar::test_criar_persiste_no_banco PASSED
tests/test_ocorrencia_repository.py::TestBuscarPorId::test_retorna_ocorrencia_existente PASSED
tests/test_ocorrencia_repository.py::TestBuscarPorId::test_retorna_none_para_id_inexistente PASSED
tests/test_ocorrencia_repository.py::TestBuscarPorRegiaoEPeriodo::test_retorna_ocorrencias_da_regiao_no_periodo PASSED
tests/test_ocorrencia_repository.py::TestBuscarPorRegiaoEPeriodo::test_nao_retorna_outra_regiao PASSED
tests/test_ocorrencia_repository.py::TestBuscarPorRegiaoEPeriodo::test_respeita_limit_e_offset PASSED
tests/test_ocorrencia_repository.py::TestContarPorRegiao::test_conta_corretamente PASSED
tests/test_ocorrencia_repository.py::TestBuscarPendentesResumo::test_retorna_apenas_pendentes PASSED
tests/test_ocorrencia_repository.py::TestAtualizarResumo::test_atualiza_campos_corretamente PASSED
tests/test_risco_service.py::TestCalcularRisco::test_retorna_baixo_para_menos_de_20 PASSED
tests/test_risco_service.py::TestCalcularRisco::test_retorna_medio_para_20_a_49 PASSED
tests/test_risco_service.py::TestCalcularRisco::test_retorna_alto_para_50_ou_mais PASSED
tests/test_risco_service.py::TestCalcularRisco::test_limiares_corretos PASSED

========================= 14 passed in 0.52s =========================
```

**Docker rodando:**
```
NAMES             STATUS                   PORTS
safestreets_api   Up 22 seconds            0.0.0.0:8000->8000/tcp
safestreets_db    Up 3 minutes (healthy)   0.0.0.0:5432->5432/tcp
```

---

## Impactos e riscos

- **Variável de ambiente obrigatória em produção:** `DATABASE_URL` deve ser configurada no ambiente de deploy. O fallback `postgresql://admin:123@localhost:5432/safestreets` é exclusivo para desenvolvimento local.
- **Redis pendente:** o cache atual é in-memory e **não persiste entre reinicializações** do processo. Para produção, o módulo `cache_redis.py` deve ser adotado após a resolução do ADR-003.
- **Dockerfile adicionado:** o `docker-compose up` agora tenta fazer build da imagem do backend. Se o Dockerfile for alterado, o rebuild pode ser forçado com `docker-compose build api`.

---

## Checklist

- [x] Código segue o padrão do projeto (Repository Pattern, separação de camadas)
- [x] Testes adicionados — 14 testes cobrindo repository e service
- [x] Testado localmente — migration aplicada, Docker rodando, testes passando
- [x] Documentação atualizada — `docs/arquitetura/Specs_banco_de_dados/` criado
- [x] `requirements.txt` atualizado com `alembic`
- [x] Variáveis sensíveis fora do código (RNF07 atendido)

---

## Observações adicionais

- Os testes de repository usam SQLite in-memory para rodar sem Docker, mantendo a CI independente de infraestrutura externa.
- O próximo passo natural é a criação dos endpoints `GET /ocorrencias` e `GET /ocorrencias/{id}` que consumirão o `OcorrenciaRepository` já implementado.
