### PR TITLE
feat: containeriza frontend Next.js com Docker

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -37,6 +37,22 @@ services:
     # Aplica as migrations (cria as tabelas) antes de subir o servidor.
     command: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
 
+  # Contêiner 3: Frontend Next.js
+  frontend:
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile
+    container_name: safestreets_frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=http://localhost:8000
+    depends_on:
+      - api
+    volumes:
+      - ../frontend:/app
+      - /app/node_modules
+
 # criacao do volume para o banco de dados
 volumes:
   postgres_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
##  Descrição
Adiciona o `Dockerfile` para o frontend Next.js e configura o serviço
correspondente no `docker-compose.yml`, permitindo que o frontend suba
em container junto ao banco de dados e à API.

##  Tipo de mudança
- [ ]  Bug fix
- [x]  Nova funcionalidade
- [ ]  Refatoração
- [ ]  Documentação
- [ ]  Melhoria de performance
- [x]  Testes

##  Issue relacionada
-

##  Como testar
1. Fazer checkout na branch `feat/docker-frontend`
2. Entrar na pasta `backend/`
3. Rodar `docker-compose up --build`
4. Acessar `http://localhost:3000` e verificar se o frontend sobe
5. Acessar `http://localhost:8000/docs` e verificar se a API responde

##  Evidências (se aplicável)
-

##  Impactos e riscos
Nenhum impacto no código existente. O frontend em Docker só é utilizado
ao rodar `docker-compose up`, não interferindo no desenvolvimento local.

##  Checklist
- [x] Código segue o padrão do projeto
- [ ] Testes adicionados/atualizados (se necessário)
- [ ] Testado localmente
- [ ] Documentação atualizada (se necessário)

##  Observações adicionais
- O frontend se comunica com a API via `NEXT_PUBLIC_API_URL=http://localhost:8000`
- Hot reload está habilitado via volume no docker-compose
