### PR TITLE
feat: melhora visual do card DetalhesOcorrencia

### DIFF
--- a/frontend/__tests__/components/DetalhesOcorrencia.test.tsx
+++ b/frontend/__tests__/components/DetalhesOcorrencia.test.tsx
@@ -18,16 +18,22 @@ describe("DetalhesOcorrencia", () => {
     mockGerarResumoIA.mockReset();
   });
 
-  it("renders título, risco, RA, região, data and resumo", () => {
+  it("renders título, risco, RA, região e data", () => {
     mockGerarResumoIA.mockReturnValue(new Promise(() => {}));
     render(<DetalhesOcorrencia noticia={noticia} onFechar={() => {}} />);
 
     expect(screen.getByText(noticia.titulo)).toBeInTheDocument();
     expect(screen.getByText(noticia.risco)).toBeInTheDocument();
-    expect(screen.getByText(noticia.ra)).toBeInTheDocument();
+    expect(screen.getByText(`RA — ${noticia.ra}`)).toBeInTheDocument();
     expect(screen.getByText(noticia.regiao)).toBeInTheDocument();
     expect(screen.getByText(noticia.data)).toBeInTheDocument();
-    expect(screen.getByText(noticia.resumo)).toBeInTheDocument();
+  });
+
+  it("não exibe o resumo breve da notícia", () => {
+    mockGerarResumoIA.mockReturnValue(new Promise(() => {}));
+    render(<DetalhesOcorrencia noticia={noticia} onFechar={() => {}} />);
+
+    expect(screen.queryByText(noticia.resumo)).not.toBeInTheDocument();
   });
 
   it("shows a loading indicator while the AI summary is being generated", () => {

--- a/frontend/__tests__/components/MapaInterativo.test.tsx
+++ b/frontend/__tests__/components/MapaInterativo.test.tsx
@@ -119,7 +119,7 @@ describe("MapaInterativo", () => {
 
       const detalhes = screen.getByLabelText("Detalhes da ocorrência");
       expect(detalhes).toHaveTextContent(noticia.titulo);
-      expect(detalhes).toHaveTextContent(noticia.resumo);
+      expect(detalhes).not.toHaveTextContent(noticia.resumo);
     });
 
     it("calls onFecharDetalhes when the close button is clicked", async () => {

--- a/frontend/components/DetalhesOcorrencia/DetalhesOcorrencia.module.css
+++ b/frontend/components/DetalhesOcorrencia/DetalhesOcorrencia.module.css
@@ -6,14 +6,15 @@
   z-index: 2000;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  width: 340px;
-  max-height: calc(100% - 32px);
+  gap: 16px;
+  width: min(580px, calc(100% - 48px));
+  min-height: 480px;
+  max-height: calc(100vh - 80px);
   overflow-y: auto;
-  padding: 24px;
-  border-radius: 16px;
+  padding: 32px;
+  border-radius: 20px;
   background: var(--cor-superficie);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.22);
   font-family: var(--font-body);
   color: var(--cor-texto);
 }
@@ -65,18 +66,24 @@
 .detalhes {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.infoBloco {
+  display: inline-flex;
+  align-items: center;
   gap: 4px;
-}
-
-.linha {
-  display: flex;
-  gap: 8px;
-  font-size: 0.9rem;
-}
-
-.linha dt {
+  padding: 2px 8px;
+  border-radius: 5px;
+  background: var(--cor-fundo);
+  font-size: 0.75rem;
   font-weight: 600;
-  color: var(--cor-cinza);
+  color: var(--cor-texto);
+}
+
+.infoBlocoLocalizacao {
+  background: var(--cor-amarelo);
 }
 
 .resumo {
@@ -85,10 +92,12 @@
 }
 
 .resumoIA {
-  padding: 16px;
+  flex: 1;
+  padding: 20px;
   border: 1px solid var(--cor-verde);
   border-radius: 12px;
   background: var(--verde-tint);
+  min-height: 200px;
 }
 
 .resumoIATitulo {

--- a/frontend/components/DetalhesOcorrencia/DetalhesOcorrencia.tsx
+++ b/frontend/components/DetalhesOcorrencia/DetalhesOcorrencia.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import type { Noticia } from "@/utils/noticias";
 import { gerarResumoIA } from "@/utils/iaResumo";
+import { PinIcon } from "@/components/icons";
 import styles from "./DetalhesOcorrencia.module.css";
 
 interface DetalhesOcorrenciaProps {
@@ -50,22 +51,14 @@ export default function DetalhesOcorrencia({ noticia, onFechar }: DetalhesOcorre
       </button>
       <span className={`${styles.badgeRisco} ${RISCO_CLASSNAME[noticia.risco]}`}>{noticia.risco}</span>
       <h2 className={styles.titulo}>{noticia.titulo}</h2>
-      <dl className={styles.detalhes}>
-        <div className={styles.linha}>
-          <dt>RA</dt>
-          <dd>{noticia.ra}</dd>
+      <div className={styles.detalhes}>
+        <div className={styles.infoBloco}>RA — {noticia.ra}</div>
+        <div className={`${styles.infoBloco} ${styles.infoBlocoLocalizacao}`}>
+          <PinIcon size={12} />
+          {noticia.regiao}
         </div>
-        <div className={styles.linha}>
-          <dt>Localização</dt>
-          <dd>{noticia.regiao}</dd>
-        </div>
-        <div className={styles.linha}>
-          <dt>Data</dt>
-          <dd>{noticia.data}</dd>
-        </div>
-      </dl>
-
-      <p className={styles.resumo}>{noticia.resumo}</p>
+        <div className={styles.infoBloco}>{noticia.data}</div>
+      </div>
 
       <section className={styles.resumoIA} aria-label="Resumo gerado por IA">
         <h3 className={styles.resumoIATitulo}>Resumo gerado por IA</h3>


### PR DESCRIPTION
##  Descrição
Melhora visual do card de DetalhesOcorrencia: aumenta as dimensões
do card, substitui os itens de detalhe por blocos coloridos compactos
(cinza para RA e Data, amarelo com ícone de pin para Localização),
remove o resumo breve da notícia e expande a área do resumo gerado
por IA. Testes atualizados para refletir as mudanças.

##  Tipo de mudança
- [ ]  Bug fix
- [ ]  Nova funcionalidade
- [x]  Refatoração
- [ ]  Documentação
- [ ]  Melhoria de performance
- [x]  Testes

##  Issue relacionada
-

##  Como testar
1. Fazer checkout na branch `feat/frontend-aparencia`
2. Rodar `npm run dev` dentro da pasta `frontend/`
3. Acessar `http://localhost:3000`
4. Abrir o mapa e clicar em "Ver detalhes" em qualquer ocorrência
5. Verificar que o card está maior, com os blocos coloridos compactos e sem o resumo breve
6. Rodar `npm test` dentro de `frontend/` e confirmar que todos os testes passam

##  Evidências (se aplicável)
-

##  Impactos e riscos
Mudanças visuais restritas ao componente `DetalhesOcorrencia`.
Nenhum outro componente foi alterado.

##  Checklist
- [x] Código segue o padrão do projeto
- [x] Testes adicionados/atualizados (se necessário)
- [ ] Testado localmente
- [ ] Documentação atualizada (se necessário)

##  Observações adicionais
- O campo `resumo` da notícia foi removido do card — apenas o resumo gerado por IA é exibido
- Os blocos coloridos seguem os design tokens do projeto (`--cor-fundo` e `--cor-amarelo`)
