### PR TITLE
feat: melhora visual do CardResumo

### DIFF
--- a/frontend/__tests__/components/CardResumo.test.tsx
+++ b/frontend/__tests__/components/CardResumo.test.tsx
@@ -11,7 +11,7 @@ describe("CardResumo", () => {
     render(<CardResumo noticia={noticia} onVerDetalhes={() => {}} />);
     expect(screen.getByText(noticia.risco)).toBeInTheDocument();
     expect(screen.getByText(noticia.titulo)).toBeInTheDocument();
-    expect(screen.getByText(noticia.ra)).toBeInTheDocument();
+    expect(screen.getByText(`RA — ${noticia.ra}`)).toBeInTheDocument();
     expect(screen.getByText(noticia.regiao)).toBeInTheDocument();
     expect(screen.getByText(noticia.data)).toBeInTheDocument();
   });

--- a/frontend/components/CardResumo/CardResumo.module.css
+++ b/frontend/components/CardResumo/CardResumo.module.css
@@ -3,9 +3,9 @@
   flex-direction: column;
   gap: 6px;
   width: 220px;
-  padding: 12px;
-  border: 1px solid var(--cor-verde);
-  border-radius: 12px;
+  padding: 12px 12px 12px 16px;
+  border-left: 4px solid var(--cor-verde);
+  border-radius: 0 12px 12px 0;
   background: var(--cor-superficie);
   font-family: var(--font-body);
 }
@@ -42,23 +42,24 @@
 .detalhes {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  align-items: flex-start;
+  gap: 4px;
 }
 
-.linha {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
-  font-size: 0.75rem;
-  color: var(--cor-cinza);
-}
-
-.linha dt {
+.infoBloco {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 5px;
+  background: var(--cor-fundo);
+  font-size: 0.7rem;
   font-weight: 600;
+  color: var(--cor-texto);
 }
 
-.linha dd {
-  text-align: right;
+.infoBlocoLocalizacao {
+  background: var(--cor-amarelo);
 }
 
 .verDetalhes {

--- a/frontend/components/CardResumo/CardResumo.tsx
+++ b/frontend/components/CardResumo/CardResumo.tsx
@@ -1,4 +1,5 @@
 import type { Noticia } from "@/utils/noticias";
+import { PinIcon } from "@/components/icons";
 import styles from "./CardResumo.module.css";
 
 interface CardResumoProps {
@@ -17,20 +18,14 @@ export default function CardResumo({ noticia, onVerDetalhes }: CardResumoProps) 
     <article className={styles.card} aria-label="Card resumo da ocorrência">
       <span className={`${styles.badgeRisco} ${RISCO_CLASSNAME[noticia.risco]}`}>{noticia.risco}</span>
       <h3 className={styles.titulo}>{noticia.titulo}</h3>
-      <dl className={styles.detalhes}>
-        <div className={styles.linha}>
-          <dt>RA</dt>
-          <dd>{noticia.ra}</dd>
+      <div className={styles.detalhes}>
+        <div className={styles.infoBloco}>RA — {noticia.ra}</div>
+        <div className={`${styles.infoBloco} ${styles.infoBlocoLocalizacao}`}>
+          <PinIcon size={10} />
+          {noticia.regiao}
         </div>
-        <div className={styles.linha}>
-          <dt>Localização</dt>
-          <dd>{noticia.regiao}</dd>
-        </div>
-        <div className={styles.linha}>
-          <dt>Data</dt>
-          <dd>{noticia.data}</dd>
-        </div>
-      </dl>
+        <div className={styles.infoBloco}>{noticia.data}</div>
+      </div>
       <button type="button" className={styles.verDetalhes} onClick={onVerDetalhes}>
         Ver detalhes
       </button>


### PR DESCRIPTION
##  Descrição
Melhora visual do CardResumo: substitui a borda verde completa por uma
barra de acento na lateral esquerda, adiciona blocos coloridos compactos
para RA (cinza), Localização (amarelo com ícone de pin) e Data (cinza).
Testes atualizados para refletir as mudanças.

##  Tipo de mudança
- [ ]  Bug fix
- [ ]  Nova funcionalidade
- [x]  Refatoração
- [ ]  Documentação
- [ ]  Melhoria de performance
- [x]  Testes

##  Issue relacionada
-

##  Como testar
1. Fazer checkout na branch `feat/frontend-card-resumo-aparencia`
2. Rodar `npm run dev` dentro da pasta `frontend/`
3. Acessar `http://localhost:3000/mapa`
4. Clicar em um marcador no mapa e verificar o CardResumo no popup
5. Conferir a barra verde colada na lateral esquerda e os blocos coloridos
6. Rodar `npm test` dentro de `frontend/` e confirmar que todos os testes passam

##  Evidências (se aplicável)
-

##  Impactos e riscos
Mudanças visuais restritas ao componente `CardResumo`.
Nenhum outro componente foi alterado.

##  Checklist
- [x] Código segue o padrão do projeto
- [x] Testes adicionados/atualizados (se necessário)
- [ ] Testado localmente
- [ ] Documentação atualizada (se necessário)

##  Observações adicionais
- Os blocos coloridos seguem os design tokens do projeto (`--cor-fundo` e `--cor-amarelo`)
- A barra de acento usa `border-radius: 0 12px 12px 0` para encostar nas bordas superior e inferior do card
