### PR TITLE
feat: expande schema OcorrenciaOut com campos adicionais

### DIFF
--- a/backend/app/schemas/ocorrencia.py
+++ b/backend/app/schemas/ocorrencia.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel, field_validator
 
 
@@ -26,6 +28,10 @@ class OcorrenciaOut(BaseModel):
     titulo: str
     latitude: float
     longitude: float
+    regiao: str | None = None
+    risco: str | None = None
+    resumo: str | None = None
+    data: datetime | None = None
 
 
 class OcorrenciaListResponse(BaseModel):

--- a/backend/app/services/ocorrencias.py
+++ b/backend/app/services/ocorrencias.py
@@ -11,6 +11,10 @@ def _to_out(o: Ocorrencia) -> OcorrenciaOut:
         titulo=o.titulo_noticia,
         latitude=float(o.latitude),
         longitude=float(o.longitude),
+        regiao=o.regiao_administrativa,
+        risco=o.risco_nivel,
+        resumo=o.resumo_gemini,
+        data=o.data_ocorrencia,
     )
 
 

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -53,7 +53,16 @@ def test_create_rejeita_campo_faltando():
 def test_out_serializa_campos():
     out = OcorrenciaOut(id=1, titulo="Teste", latitude=-15.79, longitude=-47.88)
     dump = out.model_dump()
-    assert dump == {"id": 1, "titulo": "Teste", "latitude": -15.79, "longitude": -47.88}
+    assert dump == {
+        "id": 1,
+        "titulo": "Teste",
+        "latitude": -15.79,
+        "longitude": -47.88,
+        "regiao": None,
+        "risco": None,
+        "resumo": None,
+        "data": None,
+    }
 
 
 # ---- Envelopes: defaults ----


### PR DESCRIPTION
##  Descrição
Este PR resolve a lacuna de dados apontada pelo frontend para a renderização dos cards (RF04/RF10). O schema `OcorrenciaOut` foi expandido para expor as informações que já existiam no banco, mas eram filtradas pela API.

Detalhes técnicos:
- Foram adicionados os campos opcionais `regiao`, `risco`, `resumo` e `data` no schema de resposta.
- O método de mapeamento (`_to_out`) no service foi atualizado para extrair esses dados diretamente do model.
- Os campos fundamentais `lat` e `lng` foram mantidos intactos.
- O teste unitário `test_out_serializa_campos` foi devidamente atualizado para refletir o novo contrato.

##  Tipo de mudança
- [ ]  Bug fix
- [x]  Nova funcionalidade
- [ ]  Refatoração
- [ ]  Documentação
- [ ]  Melhoria de performance
- [x]  Testes

##  Issue relacionada
Atende à necessidade de dados do RF04 e RF10.

##  Como testar
Passo a passo para validar
1. Faça o checkout para a branch: `git checkout feat/expansao-ocorrencia-out`
2. Rode a bateria de testes unitários: `python -m pytest tests/test_schemas.py`
3. Todos os testes devem passar (o assert foi atualizado para esperar os novos campos).
4. Suba a aplicação com `uvicorn backend.app.main:app --reload`.
5. Acesse o endpoint `GET /ocorrencias` via Swagger. Sem o banco de dados ativo, a API deve retornar graciosamente o erro 503 (comportamento de fallback esperado e mantido).

##  Evidências (se aplicável)
<img width="877" height="339" alt="image" src="https://github.com/user-attachments/assets/5c2bc015-b27a-4760-93c5-4d82bb32e054" />

<img width="1417" height="716" alt="image" src="https://github.com/user-attachments/assets/df9d33d5-c461-4716-91a5-14078c4e2c49" />


##  Impactos e riscos
Baixíssimo. Como os novos campos são opcionais, a mudança não quebra contratos anteriores, apenas enriquece o payload de resposta para quem precisa consumi-lo.

##  Checklist
- [x] Código segue o padrão do projeto
- [x] Testes adicionados/atualizados (se necessário)
- [x] Testado localmente (via testes automatizados)
- [ ] Documentação atualizada (se necessário)

##  Observações adicionais
- O frontend agora tem os dados necessários à disposição assim que o banco de dados oficial for populado e integrado.