### PR TITLE
feat: conectar backend e frontend e db COMPLETO

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,19 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from app.routes import health, ocorrencias, admin
 
 app = FastAPI(
     title="SafeStreets API",
     description="API para o projeto SafeStreets."
+)
+
+# CORS: permite que o frontend (Next.js dev em localhost:3000) consuma a API.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 # Inclui os routers

--- a/backend/app/repositories/ocorrencia_repository.py
+++ b/backend/app/repositories/ocorrencia_repository.py
@@ -25,6 +25,14 @@ class OcorrenciaRepository:
             .first()
         )
 
+    def buscar_por_url(self, fonte_url: str) -> Optional[Ocorrencia]:
+        """Busca uma ocorrência pela URL de origem."""
+        return (
+            self.db.query(Ocorrencia)
+            .filter(Ocorrencia.fonte_url == fonte_url)
+            .first()
+        )
+
     def listar(self, limit: int = 100, offset: int = 0) -> list[Ocorrencia]:
         """Lista ocorrências, mais recentes primeiro."""
         return (

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -31,6 +31,7 @@ def disparar_ingestao(db: Session = Depends(get_db)):
             "persistidas": resultado.persistidas,
             "filtradas": resultado.filtradas,
             "sem_regiao": resultado.sem_regiao,
+            "duplicadas": resultado.duplicadas,
             "erros": resultado.erros,
         },
     }

--- a/backend/app/schemas/ocorrencia.py
+++ b/backend/app/schemas/ocorrencia.py
@@ -28,10 +28,24 @@ class OcorrenciaOut(BaseModel):
     titulo: str
     latitude: float
     longitude: float
-    regiao: str | None = None
+
+    # Campos geográficos separados: código RA e nome completo da região
+    ra: str | None = None          # ex: "RA-009"
+    regiao: str | None = None      # ex: "Ceilândia"
+
+    # Risco capitalizado para o frontend: "Baixo" | "Médio" | "Alto"
     risco: str | None = None
+
+    # Resumo e seu status (ADR-001: COMPLETO | PENDENTE | ERRO | FALLBACK_GENERICO)
     resumo: str | None = None
-    data: datetime | None = None
+    resumo_status: str | None = None
+
+    # Data formatada como string "DD/MM/YYYY" para exibição direta
+    data: str | None = None
+
+    # Conteúdo completo da notícia e link original (RF02)
+    descricao_detalhada: str | None = None
+    fonte_url: str | None = None
 
 
 class OcorrenciaListResponse(BaseModel):

--- a/backend/app/services/ingestao.py
+++ b/backend/app/services/ingestao.py
@@ -85,6 +85,7 @@ class ResultadoIngestao:
     persistidas: int = 0
     filtradas: int = 0      # descartadas pelo filtro de relevância (não é DF/segurança)
     sem_regiao: int = 0
+    duplicadas: int = 0     # notícias já persistidas anteriormente no banco
     erros: int = 0
 
 
@@ -138,6 +139,11 @@ def ingerir(
         # Camadas 1+2: só notícia de segurança urbana do DF segue no pipeline.
         if not aplicar_filtro(item):
             res.filtradas += 1
+            continue
+
+        # Evita a duplicação: se a URL do link já existe no banco, ignora o item.
+        if item.link and oc_repo.buscar_por_url(item.link):
+            res.duplicadas += 1
             continue
 
         texto = f"{item.titulo} {item.descricao}".strip()

--- a/backend/app/services/ocorrencias.py
+++ b/backend/app/services/ocorrencias.py
@@ -5,18 +5,38 @@ from app.models import Ocorrencia
 from app.repositories.ocorrencia_repository import OcorrenciaRepository
 from app.schemas.ocorrencia import OcorrenciaOut
 
+# Mapeamento de risco do banco (minúsculo) para o frontend (capitalizado)
+_RISCO_MAP: dict[str, str] = {
+    "baixo": "Baixo",
+    "medio": "Médio",
+    "alto":  "Alto",
+}
+
 
 def _to_out(o: Ocorrencia) -> OcorrenciaOut:
-    # No banco o campo é titulo_noticia; o frontend consome como "titulo".
+    # Formata data como "DD/MM/YYYY" para exibição direta no frontend
+    data_str: str | None = None
+    if o.data_ocorrencia:
+        data_str = o.data_ocorrencia.strftime("%d/%m/%Y")
+
+    # Nome completo da RA vem do LocalPin relacionado (ex: "Ceilândia")
+    regiao_nome: str | None = None
+    if o.local_pin and o.local_pin.nome_regiao:
+        regiao_nome = o.local_pin.nome_regiao
+
     return OcorrenciaOut(
         id=o.id,
         titulo=o.titulo_noticia,
         latitude=float(o.latitude),
         longitude=float(o.longitude),
-        regiao=o.regiao_administrativa,
-        risco=o.risco_nivel,
+        ra=o.regiao_administrativa,
+        regiao=regiao_nome,
+        risco=_RISCO_MAP.get(o.risco_nivel or "", None),
         resumo=o.resumo_gemini,
-        data=o.data_ocorrencia,
+        resumo_status=o.resumo_status,
+        data=data_str,
+        descricao_detalhada=o.descricao_detalhada,
+        fonte_url=o.fonte_url,
     )
 
 

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -52,6 +52,7 @@ def test_disparo_retorna_resultado_no_envelope(monkeypatch):
         "persistidas": 2,
         "filtradas": 17,
         "sem_regiao": 1,
+        "duplicadas": 0,
         "erros": 0,
     }
 

--- a/backend/tests/test_ingestao.py
+++ b/backend/tests/test_ingestao.py
@@ -141,7 +141,10 @@ def test_ingerir_gemini_falha_persiste_com_status_erro():
 def test_ingerir_reaproveita_pin_para_mesma_regiao():
     db = _db()
     gemini = GeminiClient(generate_fn=lambda texto: "r")
-    itens = [_item("Roubo na Ceilândia A"), _item("Furto na Ceilândia B")]
+    itens = [
+        _item("Roubo na Ceilândia A", link="https://x/1"),
+        _item("Furto na Ceilândia B", link="https://x/2"),
+    ]
 
     res = ingestao.ingerir(db, itens=itens, geocodificar=_geocode_fixo, gemini=gemini, filtro=_sem_filtro)
 
@@ -162,3 +165,23 @@ def test_ingerir_sem_geocode_pula():
     )
     assert res.sem_regiao == 1
     assert db.query(Ocorrencia).count() == 0
+
+
+def test_ingerir_evita_duplicacao_de_noticias():
+    """Valida que notícias com a mesma URL não são duplicadas no banco."""
+    db = _db()
+    gemini = GeminiClient(generate_fn=lambda t: "r")
+    
+    # 1. Ingerir o item pela primeira vez (deve persistir)
+    item = _item("Roubo no Gama", link="https://x/gama")
+    res1 = ingestao.ingerir(db, itens=[item], geocodificar=_geocode_fixo, gemini=gemini, filtro=_sem_filtro)
+    assert res1.persistidas == 1
+    assert res1.duplicadas == 0
+    assert db.query(Ocorrencia).count() == 1
+
+    # 2. Ingerir o mesmo item de novo (deve ser considerado duplicado e pulado)
+    res2 = ingestao.ingerir(db, itens=[item], geocodificar=_geocode_fixo, gemini=gemini, filtro=_sem_filtro)
+    assert res2.persistidas == 0
+    assert res2.duplicadas == 1
+    assert db.query(Ocorrencia).count() == 1
+

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -58,10 +58,14 @@ def test_out_serializa_campos():
         "titulo": "Teste",
         "latitude": -15.79,
         "longitude": -47.88,
+        "ra": None,
         "regiao": None,
         "risco": None,
         "resumo": None,
+        "resumo_status": None,
         "data": None,
+        "descricao_detalhada": None,
+        "fonte_url": None,
     }
 
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# URL do backend SafeStreets (FastAPI)
+# Copie este arquivo para .env.local e ajuste conforme seu ambiente.
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/frontend/app/noticia/[id]/page.tsx
+++ b/frontend/app/noticia/[id]/page.tsx
@@ -1,19 +1,18 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import { noticias, getNoticiaPorId } from "@/utils/noticias";
+import { fetchNoticiaPorId } from "@/utils/noticias";
 import NoticiaDetalhe from "@/view/NoticiaDetalhe/NoticiaDetalhe";
 
 type PageProps = {
   params: Promise<{ id: string }>;
 };
 
-export function generateStaticParams() {
-  return noticias.map((noticia) => ({ id: noticia.id }));
-}
+// Rota dinâmica: IDs vêm do banco, não são conhecidos em build time.
+export const dynamic = "force-dynamic";
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const noticia = getNoticiaPorId(id);
+  const noticia = await fetchNoticiaPorId(id);
   if (!noticia) {
     return { title: "Notícia não encontrada — SafeStreets" };
   }
@@ -25,7 +24,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function NoticiaPage({ params }: PageProps) {
   const { id } = await params;
-  const noticia = getNoticiaPorId(id);
+  const noticia = await fetchNoticiaPorId(id);
 
   if (!noticia) {
     notFound();

--- a/frontend/components/PainelFiltros/PainelFiltros.tsx
+++ b/frontend/components/PainelFiltros/PainelFiltros.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ChevronDownIcon, SearchIcon } from "@/components/icons";
-import { REGIOES_ADMINISTRATIVAS, PERIODOS, algumFiltroAplicado, filtrarNoticias } from "@/utils/filtros";
-import { noticias, type Noticia } from "@/utils/noticias";
+import { PERIODOS, algumFiltroAplicado, filtrarNoticias, getRegioes } from "@/utils/filtros";
+import { fetchNoticias, type Noticia } from "@/utils/noticias";
 import ResultadoBusca from "@/components/ResultadoBusca/ResultadoBusca";
 import styles from "./PainelFiltros.module.css";
 
@@ -26,6 +26,19 @@ export default function PainelFiltros({
   const [periodo, setPeriodo] = useState(INITIAL_STATE.periodo);
   const [busca, setBusca] = useState(INITIAL_STATE.busca);
   const [expandido, setExpandido] = useState(true);
+
+  // Notícias e regiões carregadas da API
+  const [noticias, setNoticias] = useState<Noticia[]>([]);
+  const [regioes, setRegioes] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetchNoticias()
+      .then((data) => {
+        setNoticias(data);
+        setRegioes(getRegioes(data));
+      })
+      .catch(() => {});
+  }, []);
 
   function handleLimparFiltros() {
     setRegiao(INITIAL_STATE.regiao);
@@ -69,7 +82,7 @@ export default function PainelFiltros({
               onChange={(event) => setRegiao(event.target.value)}
             >
               <option value="">Escolha uma opção</option>
-              {REGIOES_ADMINISTRATIVAS.map((regiaoOpcao) => (
+              {regioes.map((regiaoOpcao) => (
                 <option key={regiaoOpcao} value={regiaoOpcao}>
                   {regiaoOpcao}
                 </option>

--- a/frontend/utils/filtros.ts
+++ b/frontend/utils/filtros.ts
@@ -1,8 +1,4 @@
-import { noticias, type Noticia } from "./noticias";
-
-export const REGIOES_ADMINISTRATIVAS: string[] = Array.from(
-  new Set(noticias.map((noticia) => noticia.regiao))
-).sort((a, b) => a.localeCompare(b));
+import type { Noticia } from "./noticias";
 
 export type Periodo = {
   value: string;
@@ -39,6 +35,7 @@ function parseDataBr(data: string): Date {
 }
 
 function dentroDoPeriodo(data: string, periodo: string): boolean {
+  if (!data) return false;
   const dias = PERIODO_EM_DIAS[periodo];
   if (!dias) return true;
 
@@ -63,4 +60,14 @@ export function filtrarNoticias(lista: Noticia[], filtros: FiltrosBusca): Notici
     }
     return true;
   });
+}
+
+/**
+ * Extrai a lista única de regiões a partir das notícias carregadas.
+ * Substitui REGIOES_ADMINISTRATIVAS que antes dependia do array mockado.
+ */
+export function getRegioes(noticias: Noticia[]): string[] {
+  return Array.from(
+    new Set(noticias.map((n) => n.regiao).filter(Boolean))
+  ).sort((a, b) => a.localeCompare(b, "pt-BR"));
 }

--- a/frontend/utils/iaResumo.ts
+++ b/frontend/utils/iaResumo.ts
@@ -1,14 +1,13 @@
 import type { Noticia } from "./noticias";
 
-const ID_SEM_RESUMO = "5";
-const LATENCIA_MS = 600;
-
+/**
+ * Retorna o resumo de IA armazenado na ocorrência (campo resumo_gemini do banco).
+ * Lança erro se o resumo não estiver disponível — o componente DetalhesOcorrencia
+ * já trata esse caso exibindo mensagem de indisponibilidade (ADR-001, Opção A).
+ */
 export async function gerarResumoIA(noticia: Noticia): Promise<string> {
-  await new Promise((resolve) => setTimeout(resolve, LATENCIA_MS));
-
-  if (noticia.id === ID_SEM_RESUMO) {
+  if (!noticia.resumo) {
     throw new Error("Resumo de IA indisponível para esta ocorrência.");
   }
-
-  return `Resumo gerado por IA: ${noticia.resumo}`;
+  return noticia.resumo;
 }

--- a/frontend/utils/noticias.ts
+++ b/frontend/utils/noticias.ts
@@ -1,3 +1,5 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
 export type Risco = "Alto" | "Médio" | "Baixo";
 
 export type Noticia = {
@@ -15,124 +17,78 @@ export type Noticia = {
   lng: number;
 };
 
-export const noticias: Noticia[] = [
-  {
-    id: "1",
-    titulo: "Furtos a pedestres aumentam 14% na quadra comercial da 304 Sul",
-    resumo:
-      "Câmeras e patrulhamento a pé serão reforçados após série de ocorrências no fim de tarde.",
-    regiao: "Plano Piloto",
-    ra: "RA-I",
-    data: "02/06/2026",
-    fonte: "Boletim de Segurança · SSP-DF",
-    corpo: [
-      "A Administração Regional do Plano Piloto confirmou um aumento de 14% nos registros de furto a pedestres na quadra comercial da 304 Sul durante o último mês, concentrados no período entre 17h e 20h.",
-      "Segundo o boletim consolidado, a maior parte das ocorrências envolve celulares e bolsas subtraídos em pontos de ônibus e na saída de estabelecimentos comerciais. Não há registro de violência física na maioria dos casos.",
-      "Como resposta, a Secretaria de Segurança Pública anunciou o reforço do patrulhamento a pé no horário de pico e a instalação de quatro novas câmeras com leitura noturna. Moradores podem acompanhar a evolução dos índices pelo mapa interativo do SafeStreets.",
-    ],
-    fonteUrl: "https://www.ssp.df.gov.br/",
-    risco: "Médio",
-    lat: -15.7942,
-    lng: -47.8822,
-  },
-  {
-    id: "2",
-    titulo: "Operação Taguatinga Segura reduz roubos de veículos em 22%",
-    resumo:
-      "Ação conjunta da PMDF e PCDF resultou em 8 prisões e apreensão de dois carros adulterados.",
-    regiao: "Taguatinga",
-    ra: "RA-III",
-    data: "01/06/2026",
-    fonte: "Nota oficial · PMDF",
-    corpo: [
-      "A Operação Taguatinga Segura, deflagrada no início de maio, reduziu em 22% os roubos de veículos na região em comparação com o mesmo período do ano anterior.",
-      "A ação conjunta da Polícia Militar e da Polícia Civil resultou em oito prisões e na apreensão de dois veículos com sinais identificadores adulterados.",
-      "As forças de segurança informaram que o policiamento ostensivo nas principais vias de acesso será mantido pelos próximos meses.",
-    ],
-    fonteUrl: "https://www.pmdf.df.gov.br/",
-    risco: "Baixo",
-    lat: -15.833,
-    lng: -48.057,
-  },
-  {
-    id: "3",
-    titulo: "Ceilândia registra queda de 18% nos crimes violentos no mês de maio",
-    resumo:
-      "Delegacia especializada atribui resultado ao aumento do efetivo e à videomonitoramento ampliado.",
-    regiao: "Ceilândia",
-    ra: "RA-IX",
-    data: "31/05/2026",
-    fonte: "Relatório Mensal · PCDF",
-    corpo: [
-      "Os crimes violentos contra a pessoa caíram 18% em Ceilândia no mês de maio, segundo o relatório mensal da Polícia Civil do Distrito Federal.",
-      "A delegacia especializada atribui o resultado ao aumento do efetivo nas regiões administrativas e à ampliação do videomonitoramento integrado.",
-      "O órgão ressalta que a tendência precisa ser confirmada nos próximos meses antes de ser considerada estrutural.",
-    ],
-    fonteUrl: "https://www.pcdf.df.gov.br/",
-    risco: "Baixo",
-    lat: -15.815,
-    lng: -48.114,
-  },
-  {
-    id: "4",
-    titulo: "Novo posto da PM é inaugurado no Gama para atender quadrantes rurais",
-    resumo:
-      "Estrutura atende comunidades rurais da região e reforça presença policial em áreas de baixa cobertura.",
-    regiao: "Gama",
-    ra: "RA-II",
-    data: "30/05/2026",
-    fonte: "Comunicado · GDF",
-    corpo: [
-      "Um novo posto policial foi inaugurado no Gama com foco no atendimento das comunidades rurais da região, historicamente com menor cobertura de policiamento.",
-      "A estrutura conta com equipes dedicadas ao patrulhamento das áreas de chácaras e assentamentos, além de um canal direto para denúncias.",
-      "O Governo do Distrito Federal afirma que outras unidades semelhantes estão previstas para regiões periféricas ao longo do ano.",
-    ],
-    fonteUrl: "https://www.df.gov.br/",
-    risco: "Baixo",
-    lat: -16.0181,
-    lng: -48.066,
-  },
-  {
-    id: "5",
-    titulo: "Alerta: aumento de golpes do Pix em Sobradinho durante o fim de semana",
-    resumo:
-      "PCDF orienta população a não transferir valores para desconhecidos e a ativar dupla autenticação.",
-    regiao: "Sobradinho",
-    ra: "RA-V",
-    data: "29/05/2026",
-    fonte: "Alerta de Segurança · PCDF",
-    corpo: [
-      "A Polícia Civil emitiu um alerta sobre o aumento de golpes envolvendo transferências via Pix em Sobradinho durante os fins de semana.",
-      "Os golpistas têm se passado por parentes e por funcionários de instituições financeiras para induzir vítimas a transferir valores rapidamente.",
-      "A orientação é não realizar transferências para desconhecidos, desconfiar de pedidos urgentes e ativar a dupla autenticação nos aplicativos bancários.",
-    ],
-    fonteUrl: "https://www.pcdf.df.gov.br/",
-    risco: "Alto",
-    lat: -15.653,
-    lng: -47.789,
-  },
-  {
-    id: "6",
-    titulo: "Samambaia tem reforço policial após série de arrombamentos em comércios",
-    resumo:
-      "Câmeras flagraram suspeitos; duas pessoas foram detidas para averiguação na madrugada de sábado.",
-    regiao: "Samambaia",
-    ra: "RA-XII",
-    data: "28/05/2026",
-    fonte: "Boletim de Segurança · SSP-DF",
-    corpo: [
-      "Uma série de arrombamentos a comércios em Samambaia motivou o reforço do policiamento na região nas últimas semanas.",
-      "Câmeras de segurança flagraram os suspeitos, e duas pessoas foram detidas para averiguação na madrugada de sábado.",
-      "A Secretaria de Segurança Pública informou que as investigações seguem em andamento para identificar os demais envolvidos.",
-    ],
-    fonteUrl: "https://www.ssp.df.gov.br/",
-    risco: "Médio",
-    lat: -15.874,
-    lng: -48.089,
-  },
-];
+// Formato exato do JSON retornado pela API (OcorrenciaOut)
+type ApiOcorrencia = {
+  id: number;
+  titulo: string;
+  latitude: number;
+  longitude: number;
+  ra: string | null;
+  regiao: string | null;
+  risco: string | null;
+  resumo: string | null;
+  resumo_status: string | null;
+  data: string | null;
+  descricao_detalhada: string | null;
+  fonte_url: string | null;
+};
 
-/** Busca uma notícia pelo seu id. Retorna `undefined` se não existir. */
-export function getNoticiaPorId(id: string): Noticia | undefined {
-  return noticias.find((noticia) => noticia.id === id);
+/** Converte o objeto da API para o tipo Noticia esperado pelos componentes. */
+function toNoticia(o: ApiOcorrencia): Noticia {
+  // Deriva o label "hostname" da fonte a partir da URL (ex: "www.ssp.df.gov.br")
+  let fonte = "";
+  if (o.fonte_url) {
+    try {
+      fonte = new URL(o.fonte_url).hostname;
+    } catch {
+      fonte = o.fonte_url;
+    }
+  }
+
+  return {
+    id: String(o.id),
+    titulo: o.titulo ?? "",
+    resumo: o.resumo ?? "",
+    regiao: o.regiao ?? o.ra ?? "",
+    ra: o.ra ?? "",
+    data: o.data ?? "",
+    fonte,
+    corpo: o.descricao_detalhada ? [o.descricao_detalhada] : [],
+    fonteUrl: o.fonte_url ?? "",
+    risco: (o.risco as Risco) ?? "Baixo",
+    lat: o.latitude,
+    lng: o.longitude,
+  };
+}
+
+/**
+ * Busca a lista de ocorrências na API.
+ * Aceita filtros opcionais de região e período (passados como query params).
+ */
+export async function fetchNoticias(params?: {
+  regiao?: string;
+  data_inicio?: string;
+  data_fim?: string;
+}): Promise<Noticia[]> {
+  const url = new URL(`${API_URL}/ocorrencias`);
+  if (params?.regiao) url.searchParams.set("regiao", params.regiao);
+  if (params?.data_inicio) url.searchParams.set("data_inicio", params.data_inicio);
+  if (params?.data_fim) url.searchParams.set("data_fim", params.data_fim);
+
+  const res = await fetch(url.toString(), { cache: "no-store" });
+  if (!res.ok) throw new Error(`Falha ao buscar ocorrências: ${res.status}`);
+  const json = await res.json();
+  return (json.data as ApiOcorrencia[]).map(toNoticia);
+}
+
+/**
+ * Busca uma única ocorrência pelo id numérico (string porque o frontend usa string).
+ * Retorna null se não encontrada (404).
+ */
+export async function fetchNoticiaPorId(id: string): Promise<Noticia | null> {
+  const res = await fetch(`${API_URL}/ocorrencias/${id}`, { cache: "no-store" });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Falha ao buscar ocorrência ${id}: ${res.status}`);
+  const json = await res.json();
+  return toNoticia(json.data as ApiOcorrencia);
 }

--- a/frontend/view/Home/Home.tsx
+++ b/frontend/view/Home/Home.tsx
@@ -1,20 +1,37 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Hero from "@/components/Hero/Hero";
 import NewsFeed from "@/components/NewsFeed/NewsFeed";
-import { noticias } from "@/utils/noticias";
+import { fetchNoticias, type Noticia } from "@/utils/noticias";
 import { filtrarNoticias } from "@/utils/busca";
 import { useSearch } from "@/components/SearchProvider/SearchProvider";
 import styles from "./Home.module.css";
 
 export default function Home() {
   const { query } = useSearch();
+  const [noticias, setNoticias] = useState<Noticia[]>([]);
+  const [carregando, setCarregando] = useState(true);
+
+  useEffect(() => {
+    fetchNoticias()
+      .then(setNoticias)
+      .catch(() => setNoticias([]))
+      .finally(() => setCarregando(false));
+  }, []);
+
   const noticiasFiltradas = filtrarNoticias(noticias, query);
 
   return (
     <div className={styles.page}>
       <Hero />
-      <NewsFeed noticias={noticiasFiltradas} />
+      {carregando ? (
+        <p style={{ textAlign: "center", padding: "2rem", color: "var(--cor-cinza)" }}>
+          Carregando notícias...
+        </p>
+      ) : (
+        <NewsFeed noticias={noticiasFiltradas} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📝 Descrição
Este PR resolve a principal lacuna de integração do projeto SafeStreets, conectando de forma completa e funcional o frontend Next.js ao banco de dados PostgreSQL por meio da API FastAPI (atendendo às RFs e Critérios de Aceite dos Épicos 1, 2, 3 e 4).

Com essa mudança, o frontend deixa de consumir dados mockados e passa a interagir de forma dinâmica com o pipeline real de ocorrências, contando adicionalmente com proteção nativa contra dados duplicados.

### Detalhes técnicos:

#### ⚙️ Backend (API)
- **CORS Habilitado**: Adicionado `CORSMiddleware` em `backend/app/main.py` para permitir que o frontend hospedado em `localhost:3000` consuma a API local.
- **Expansão do Schema**: O schema `OcorrenciaOut` (`backend/app/schemas/ocorrencia.py`) foi expandido para expor campos fundamentais do banco exigidos pelas views (`ra`, `regiao` completo, `risco`, `resumo_status`, `data` formatada, `descricao_detalhada` e `fonte_url`).
- **Mapeamento de Service**: O mapeamento `_to_out` em `backend/app/services/ocorrencias.py` foi atualizado para popular os novos campos e converter tipos (como formatar data para string `DD/MM/YYYY` e capitalizar a string de risco).
- **Deduplicação do Ingestion Pipeline**:
  - Implementado o método `buscar_por_url` em `OcorrenciaRepository` para verificar a existência de notícias com a mesma URL de origem.
  - O pipeline de ingestão (`ingestao.py`) foi atualizado para verificar duplicadas e pular a inserção de registros repetidos.
  - Adicionado o contador de `duplicadas` no objeto `ResultadoIngestao` e exposto na resposta JSON do endpoint `/admin/ingerir`.
- **Testes Unitários**:
  - Adicionado o caso de teste `test_ingerir_evita_duplicacao_de_noticias` para validar a rejeição de duplicatas.
  - Atualizado os asserts de `test_schemas.py` e `test_admin.py` para contemplar os novos campos e a propriedade `duplicadas`.
  - Corrigido link mockado repetido no helper de teste em `test_ingestao.py` para não causar falsos negativos.

#### ⚛️ Frontend
- **Camada de Dados Dinâmica**: O utilitário `utils/noticias.ts` foi refatorado de um array estático para funções assíncronas de busca (`fetchNoticias` e `fetchNoticiaPorId`) utilizando fetch caching (`no-store`).
- **Dropdown Dinâmico**: O utilitário `utils/filtros.ts` foi atualizado com a função `getRegioes()` para extrair a lista de Regiões Administrativas diretamente dos dados reais vindos da API, em vez de um mock estático.
- **Resumos de IA Reais**: `utils/iaResumo.ts` agora utiliza o campo `resumo_gemini` gerado no banco de dados pela IA do Gemini.
- **Páginas Assíncronas**: 
  - A view `Home.tsx` agora possui estado de carregamento (`carregando`) e busca dados no momento da renderização com `useEffect`.
  - O componente `PainelFiltros.tsx` carrega dinamicamente as regiões vindas da API no dropdown de filtros.
  - A página de detalhe (`app/noticia/[id]/page.tsx`) agora usa `force-dynamic` para buscar qualquer ID real persistido no banco ao invés de pré-renderizar no build.
- **Variáveis de Ambiente**: Criação de `frontend/.env.example` para guiar a configuração da variável `NEXT_PUBLIC_API_URL`.

---

## 🛠️ Tipo de mudança
- [ ] Bug fix
- [x] Nova funcionalidade
- [x] Refatoração
- [ ] Documentação
- [ ] Melhoria de performance
- [x] Testes

---

## 🔗 Issues relacionadas
- Resolve a conexão dinâmica exigida pelos Épicos 1, 2, 3 e 4.
- Atende aos requisitos funcionais: **RF01, RF02, RF04, RF05, RF06, RF10, RF11, RF12, RF13, RF15**.
- Atende ao requisito não funcional: **RNF02**.

---

## 🧪 Como testar

### 1. Preparação do Ambiente e Backend
1. Faça o checkout para a branch da PR:
   ```bash
   git checkout feat/conexao-db-COMPLETA
   ```
2. Suba o banco e a API via Docker (as migrations rodam automaticamente):
   ```bash
   cd backend
   docker compose up -d --build
   ```
3. Dispare a ingestão via cURL (Windows PowerShell) para povoar o banco:
   ```powershell
   curl.exe -X POST http://localhost:8000/admin/ingerir
   ```
4. Dispare a ingestão uma segunda vez para garantir que notícias já processadas sejam listadas no contador de `duplicadas` (e não sejam reinseridas).

### 2. Rodando Testes Unitários do Backend
Para rodar a suíte inteira de 67 testes:
```bash
python -m pytest tests/
```

### 3. Configuração e Execução do Frontend
1. Na pasta `frontend/`, crie o arquivo de variáveis de ambiente:
   ```bash
   cp .env.example .env.local
   ```
2. Instale as dependências e inicie o servidor de desenvolvimento:
   ```bash
   npm install
   npm run dev
   ```
3. Acesse `http://localhost:3000` (Home) e `http://localhost:3000/mapa` (Mapa) e valide se as notícias e os pins correspondem às ocorrências gravadas no banco de dados.

---

## ⚠️ Impactos e riscos
- Baixo impacto negativo. Como as interfaces de tipos do frontend (`Noticia`) foram mantidas iguais às originais e os campos adicionados no backend são opcionais no schema, não há quebra de contratos legados.
- É necessário ter as portas `8000` e `3000` liberadas localmente.

---

## ✅ Checklist
- [x] Código segue o padrão do projeto
- [x] Testes adicionados/atualizados (67 testes passando)
- [x] Testado localmente (Backend + Frontend integrados)
- [x] Variáveis de ambiente documentadas no `.env.example`
