### PR TITLE
fix: adiciona porta 3001 ao CORS para compatibilidade com Next.js

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,10 +7,11 @@ app = FastAPI(
     description="API para o projeto SafeStreets."
 )
 
-# CORS: permite que o frontend (Next.js dev em localhost:3000) consuma a API.
+# CORS: permite que o frontend (Next.js dev em localhost:3000 ou 3001) consuma a API.
+# A porta 3001 é usada automaticamente pelo Next.js quando a 3000 está ocupada.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=["http://localhost:3000", "http://localhost:3001"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## 📝 Descrição

Este PR corrige um problema de CORS que impedia o frontend de se comunicar com a API quando o Next.js utilizava a porta `3001` como fallback.

O Next.js, quando a porta padrão `3000` já está em uso, sobe automaticamente na porta `3001`. A configuração anterior do `CORSMiddleware` só permitia requisições de `localhost:3000`, bloqueando silenciosamente todas as chamadas à API nessa situação. Com essa correção, ambas as portas são aceitas.

### Detalhes técnicos:

#### ⚙️ Backend (API)
- **CORS expandido**: A lista `allow_origins` em `backend/app/main.py` foi atualizada para incluir `http://localhost:3001`, além do `http://localhost:3000` já existente.
- **Comentário atualizado**: O comentário inline foi ajustado para documentar que a porta `3001` é usada automaticamente pelo Next.js quando a `3000` está ocupada.

```diff
- allow_origins=["http://localhost:3000"],
+ allow_origins=["http://localhost:3000", "http://localhost:3001"],
```

---

## 🛠️ Tipo de mudança
- [x] Bug fix
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação
- [ ] Melhoria de performance
- [ ] Testes

---

## 🔗 Issues relacionadas
- Garante que o ambiente de desenvolvimento local funcione independentemente de qual porta o Next.js esteja utilizando.

---

## 🧪 Como testar

1. Faça o checkout para a branch da PR:
   ```bash
   git checkout fix/cors-porta-3001
   ```
2. Suba a API via Docker:
   ```bash
   cd backend
   docker compose up -d --build
   ```
3. Inicie o frontend com outra instância do servidor de desenvolvimento já em execução (para forçar o uso da porta `3001`):
   ```bash
   cd frontend
   npm run dev
   ```
4. Verifique no terminal que o Next.js iniciou na porta `3001`.
5. Acesse `http://localhost:3001/mapa` e confirme que as notícias são carregadas corretamente a partir da API.

---

## ⚠️ Impactos e riscos
- Impacto mínimo. A mudança apenas adiciona uma origem permitida ao CORS e não altera nenhuma lógica de negócio.
- Em produção, o CORS deve ser configurado com a URL real do frontend — essa configuração é exclusiva para o ambiente de desenvolvimento local.

---

## ✅ Checklist
- [x] Código segue o padrão do projeto
- [x] Testado localmente (frontend na porta 3001 consumindo a API sem erros de CORS)
- [x] Sem impacto em outros módulos ou endpoints
