### PR TITLE
feat: adiciona opcao Todas no filtro de Regiao Administrativa do mapa

### DIFF
--- a/frontend/components/PainelFiltros/PainelFiltros.tsx
+++ b/frontend/components/PainelFiltros/PainelFiltros.tsx
@@ -19,13 +19,16 @@ interface PainelFiltrosProps {
 }
 
 export default function PainelFiltros({
-  onSelecionarNoticia = () => {},
+  onSelecionarNoticia = () => { },
   noticiaSelecionadaId,
 }: PainelFiltrosProps) {
   const [regiao, setRegiao] = useState(INITIAL_STATE.regiao);
   const [periodo, setPeriodo] = useState(INITIAL_STATE.periodo);
   const [busca, setBusca] = useState(INITIAL_STATE.busca);
   const [expandido, setExpandido] = useState(true);
+
+  // Valor especial que indica "exibir todas as regiões"
+  const TODAS_REGIOES = "todas";
 
   // Notícias e regiões carregadas da API
   const [noticias, setNoticias] = useState<Noticia[]>([]);
@@ -37,7 +40,7 @@ export default function PainelFiltros({
         setNoticias(data);
         setRegioes(getRegioes(data));
       })
-      .catch(() => {});
+      .catch(() => { });
   }, []);
 
   function handleLimparFiltros() {
@@ -46,8 +49,11 @@ export default function PainelFiltros({
     setBusca(INITIAL_STATE.busca);
   }
 
-  const filtros = { regiao, periodo, busca };
-  const filtroAplicado = algumFiltroAplicado(filtros);
+  // Quando "Todas" está selecionado, passa regiao vazia para filtrarNoticias
+  // (não filtra por região), mas mantém filtroAplicado = true para exibir resultados.
+  const eTodasRegioes = regiao === TODAS_REGIOES;
+  const filtros = { regiao: eTodasRegioes ? "" : regiao, periodo, busca };
+  const filtroAplicado = algumFiltroAplicado(filtros) || eTodasRegioes;
   const resultados = filtroAplicado ? filtrarNoticias(noticias, filtros) : [];
 
   return (
@@ -82,6 +88,7 @@ export default function PainelFiltros({
               onChange={(event) => setRegiao(event.target.value)}
             >
               <option value="">Escolha uma opção</option>
+              <option value="todas">Todas</option>
               {regioes.map((regiaoOpcao) => (
                 <option key={regiaoOpcao} value={regiaoOpcao}>
                   {regiaoOpcao}


### PR DESCRIPTION
## 📝 Descrição

Este PR adiciona a opção **"Todas"** no dropdown de seleção de Regiões Administrativas do mapa interativo.

Anteriormente, para visualizar notícias, o usuário precisava obrigatoriamente selecionar uma região específica ou fazer uma busca textual. Com esta alteração, ao selecionar "Todas", o sistema remove o filtro de região específica mantendo os demais filtros ativos (como busca ou período), permitindo listar e visualizar todas as ocorrências de uma só vez no mapa.

### Detalhes técnicos:

#### ⚛️ Frontend
- **Dropdown de Região**: Inserção da opção `<option value="todas">Todas</option>` logo abaixo da opção padrão inicial em `frontend/components/PainelFiltros/PainelFiltros.tsx`.
- **Lógica de Filtros**:
  - Adicionada a verificação `eTodasRegioes = regiao === "todas"`.
  - Quando ativa, a propriedade `regiao` enviada à função `filtrarNoticias` é mapeada como vazia `""` para que ela não seja filtrada, mas `filtroAplicado` é marcado como `true` para disparar a exibição da listagem de resultados.
  - A integração com filtros de *período* e *busca textual* continua ocorrendo normalmente sobre o conjunto completo de dados.

---

## 🛠️ Tipo de mudança
- [ ] Bug fix
- [x] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação
- [ ] Melhoria de performance
- [ ] Testes

---

## 🔗 Issues relacionadas
- Facilita a visualização global de ocorrências no mapa interativo sem a necessidade de filtrar por uma RA específica de cada vez.

---

## 🧪 Como testar

1. Faça o checkout para a nova branch:
   ```bash
   git checkout feat/filtro-todas-regioes
   ```
2. Inicie o frontend:
   ```bash
   cd frontend
   npm run dev
   ```
3. Acesse `http://localhost:3000/mapa` (ou a porta correspondente).
4. No dropdown de "Região Administrativa", selecione a opção **"Todas"**.
5. Valide se todas as notícias/pins são listados no painel lateral e renderizados no mapa.
6. Teste combinar a seleção "Todas" com o filtro de "Período" ou uma query de "Buscar" para verificar se as regras de filtragem continuam funcionando.

---

## ⚠️ Impactos e riscos
- Impacto baixo. O fluxo de filtragem padrão para as regiões individuais ou quando nenhuma opção está selecionada se manteve idêntico ao original.

---

## ✅ Checklist
- [x] Código segue o padrão do projeto
- [x] Testado localmente (todas as notícias renderizam ao selecionar "Todas")
- [x] Integração com busca por texto e períodos validada
