### PR TITLE
fix: corrige redundancia de RA duplicado nos cards de resumo

### DIFF
--- a/frontend/__tests__/components/CardResumo.test.tsx
+++ b/frontend/__tests__/components/CardResumo.test.tsx
@@ -11,7 +11,10 @@ describe("CardResumo", () => {
     render(<CardResumo noticia={noticia} onVerDetalhes={() => {}} />);
     expect(screen.getByText(noticia.risco)).toBeInTheDocument();
     expect(screen.getByText(noticia.titulo)).toBeInTheDocument();
-    expect(screen.getByText(`RA — ${noticia.ra}`)).toBeInTheDocument();
+    const raEsperada = noticia.ra.toUpperCase().startsWith("RA")
+      ? noticia.ra.replace(/^RA[-—\s]*/i, "RA — ")
+      : `RA — ${noticia.ra}`;
+    expect(screen.getByText(raEsperada)).toBeInTheDocument();
     expect(screen.getByText(noticia.regiao)).toBeInTheDocument();
     expect(screen.getByText(noticia.data)).toBeInTheDocument();
   });

--- a/frontend/__tests__/components/DetalhesOcorrencia.test.tsx
+++ b/frontend/__tests__/components/DetalhesOcorrencia.test.tsx
@@ -24,7 +24,10 @@ describe("DetalhesOcorrencia", () => {
 
     expect(screen.getByText(noticia.titulo)).toBeInTheDocument();
     expect(screen.getByText(noticia.risco)).toBeInTheDocument();
-    expect(screen.getByText(`RA — ${noticia.ra}`)).toBeInTheDocument();
+    const raEsperada = noticia.ra.toUpperCase().startsWith("RA")
+      ? noticia.ra.replace(/^RA[-—\s]*/i, "RA — ")
+      : `RA — ${noticia.ra}`;
+    expect(screen.getByText(raEsperada)).toBeInTheDocument();
     expect(screen.getByText(noticia.regiao)).toBeInTheDocument();
     expect(screen.getByText(noticia.data)).toBeInTheDocument();
   });

--- a/frontend/components/CardResumo/CardResumo.tsx
+++ b/frontend/components/CardResumo/CardResumo.tsx
@@ -19,7 +19,11 @@ export default function CardResumo({ noticia, onVerDetalhes }: CardResumoProps) 
       <span className={`${styles.badgeRisco} ${RISCO_CLASSNAME[noticia.risco]}`}>{noticia.risco}</span>
       <h3 className={styles.titulo}>{noticia.titulo}</h3>
       <div className={styles.detalhes}>
-        <div className={styles.infoBloco}>RA — {noticia.ra}</div>
+        <div className={styles.infoBloco}>
+          {noticia.ra.toUpperCase().startsWith("RA") 
+            ? noticia.ra.replace(/^RA[-—\s]*/i, "RA — ") 
+            : `RA — ${noticia.ra}`}
+        </div>
         <div className={`${styles.infoBloco} ${styles.infoBlocoLocalizacao}`}>
           <PinIcon size={10} />
           {noticia.regiao}

--- a/frontend/components/DetalhesOcorrencia/DetalhesOcorrencia.tsx
+++ b/frontend/components/DetalhesOcorrencia/DetalhesOcorrencia.tsx
@@ -52,7 +52,11 @@ export default function DetalhesOcorrencia({ noticia, onFechar }: DetalhesOcorre
       <span className={`${styles.badgeRisco} ${RISCO_CLASSNAME[noticia.risco]}`}>{noticia.risco}</span>
       <h2 className={styles.titulo}>{noticia.titulo}</h2>
       <div className={styles.detalhes}>
-        <div className={styles.infoBloco}>RA — {noticia.ra}</div>
+        <div className={styles.infoBloco}>
+          {noticia.ra.toUpperCase().startsWith("RA") 
+            ? noticia.ra.replace(/^RA[-—\s]*/i, "RA — ") 
+            : `RA — ${noticia.ra}`}
+        </div>
         <div className={`${styles.infoBloco} ${styles.infoBlocoLocalizacao}`}>
           <PinIcon size={12} />
           {noticia.regiao}


### PR DESCRIPTION
## 📝 Descrição

Este PR corrige a exibição redundante do prefixo `"RA"` nos cards de visualização de ocorrências no mapa interativo (`CardResumo` e `DetalhesOcorrencia`).

Anteriormente, a propriedade `ra` retornada da base de dados/API continha o prefixo `"RA-"` embutido (ex: `"RA-015"`). Como o frontend concatenava um prefixo estático `"RA — "` na renderização do bloco, o resultado gerava a string duplicada `"RA — RA-015"`.

### Detalhes técnicos:

#### ⚛️ Frontend
- **Formatação Condicional de RA**: Os componentes `CardResumo.tsx` e `DetalhesOcorrencia.tsx` foram atualizados para verificar se a string `noticia.ra` já inicia com a palavra `"RA"`. Em caso positivo, o prefixo redundante é limpo via expressão regular e formatado para a notação padrão do layout (`"RA — 015"`). Caso não possua, o prefixo `"RA — "` é adicionado normalmente, garantindo compatibilidade reversa.
- **Atualização de Testes**: Ajustadas as asserções em `CardResumo.test.tsx` e `DetalhesOcorrencia.test.tsx` para seguir o novo padrão de string limpo, prevenindo quebras em execuções de testes futuras.

---

## 🛠️ Tipo de mudança
- [x] Bug fix
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Documentação
- [ ] Melhoria de performance
- [ ] Testes (ajuste de testes existentes)

---

## 🧪 Como testar

1. Faça o checkout para a branch da PR:
   ```bash
   git checkout fix/card-ra-duplicado
   ```
2. Inicie o frontend:
   ```bash
   cd frontend
   npm run dev
   ```
3. Acesse o mapa interativo em `http://localhost:3000/mapa` (ou porta alternativa).
4. Clique em qualquer pin de ocorrência para abrir o popup.
5. Verifique que a linha do identificador exibe a formatação correta (ex: **`RA — 015`** ou **`RA — 001`**) em vez de duplicar o termo.
6. Clique em "Ver detalhes" e valide se o painel de detalhes exibe a mesma informação formatada corretamente.

---

## ⚠️ Impactos e riscos
- Risco zero. A alteração é estritamente de formatação de string visual nos componentes de card e não afeta regras de busca ou o backend da aplicação.

---

## ✅ Checklist
- [x] Código segue o padrão do projeto
- [x] Testado localmente
- [x] Testes unitários atualizados e adaptados para a nova string
