### PR TITLE
feat: altera o nome de Regiao Administrativa para Regiao nos filtros

### DIFF
--- a/frontend/__tests__/components/PainelFiltros.test.tsx
+++ b/frontend/__tests__/components/PainelFiltros.test.tsx
@@ -11,12 +11,12 @@ describe("PainelFiltros", () => {
       expect(screen.getByText("FILTROS")).toBeInTheDocument();
     });
 
-    it("renders the 'Região Administrativa' select with placeholder and known regions", () => {
+    it("renders the 'Região' select with placeholder and known regions", () => {
       render(<PainelFiltros />);
-      const select = screen.getByLabelText("Região Administrativa");
+      const select = screen.getByLabelText("Região");
       expect(select).toBeInTheDocument();
       expect((select as HTMLSelectElement).value).toBe("");
-      expect(screen.getByText("Escolha uma opção", { selector: "select[aria-label='Região Administrativa'] option" })).toBeInTheDocument();
+      expect(screen.getByText("Escolha uma opção", { selector: "select[aria-label='Região'] option" })).toBeInTheDocument();
       REGIOES_ADMINISTRATIVAS.forEach((regiao) => {
         expect(screen.getByRole("option", { name: regiao })).toBeInTheDocument();
       });
@@ -42,7 +42,7 @@ describe("PainelFiltros", () => {
   describe("filter interactions", () => {
     it("updates the selected região administrativa", () => {
       render(<PainelFiltros />);
-      const select = screen.getByLabelText("Região Administrativa") as HTMLSelectElement;
+      const select = screen.getByLabelText("Região") as HTMLSelectElement;
       fireEvent.change(select, { target: { value: REGIOES_ADMINISTRATIVAS[0] } });
       expect(select.value).toBe(REGIOES_ADMINISTRATIVAS[0]);
     });
@@ -65,7 +65,7 @@ describe("PainelFiltros", () => {
   describe("Limpar filtros (RF08)", () => {
     it("resets região, período and busca to their initial state (edge: clear after filling)", () => {
       render(<PainelFiltros />);
-      const regiaoSelect = screen.getByLabelText("Região Administrativa") as HTMLSelectElement;
+      const regiaoSelect = screen.getByLabelText("Região") as HTMLSelectElement;
       const periodoSelect = screen.getByLabelText("Período") as HTMLSelectElement;
       const buscaInput = screen.getByPlaceholderText("Buscar") as HTMLInputElement;
 
@@ -98,7 +98,7 @@ describe("PainelFiltros", () => {
     it("shows a list of matching results when a região filter is applied", () => {
       const onSelecionarNoticia = jest.fn();
       render(<PainelFiltros onSelecionarNoticia={onSelecionarNoticia} />);
-      const select = screen.getByLabelText("Região Administrativa") as HTMLSelectElement;
+      const select = screen.getByLabelText("Região") as HTMLSelectElement;
       const regiao = "Ceilândia";
       fireEvent.change(select, { target: { value: regiao } });
 
@@ -116,14 +116,14 @@ describe("PainelFiltros", () => {
   describe("expand/collapse (RNF05 - adherence to prototype)", () => {
     it("starts expanded, showing the filter body", () => {
       render(<PainelFiltros />);
-      expect(screen.getByLabelText("Região Administrativa")).toBeInTheDocument();
+      expect(screen.getByLabelText("Região")).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Recolher filtros" })).toBeInTheDocument();
     });
 
     it("hides the filter body when the collapse button is clicked", () => {
       render(<PainelFiltros />);
       fireEvent.click(screen.getByRole("button", { name: "Recolher filtros" }));
-      expect(screen.queryByLabelText("Região Administrativa")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Região")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Período")).not.toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Expandir filtros" })).toBeInTheDocument();
     });
@@ -140,7 +140,7 @@ describe("PainelFiltros", () => {
         fireEvent.click(screen.getByRole("button", { name: /^(Recolher|Expandir) filtros$/ }));
       toggle();
       toggle();
-      expect(screen.getByLabelText("Região Administrativa")).toBeInTheDocument();
+      expect(screen.getByLabelText("Região")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/components/PainelFiltros/PainelFiltros.tsx
+++ b/frontend/components/PainelFiltros/PainelFiltros.tsx
@@ -78,11 +78,11 @@ export default function PainelFiltros({
         <div className={styles.corpo}>
           <div className={styles.campo}>
             <label className={styles.label} htmlFor="filtro-regiao">
-              Região Administrativa
+              Região
             </label>
             <select
               id="filtro-regiao"
-              aria-label="Região Administrativa"
+              aria-label="Região"
               className={styles.select}
               value={regiao}
               onChange={(event) => setRegiao(event.target.value)}


### PR DESCRIPTION
## 📝 Descrição

Este PR altera a nomenclatura do campo de `"Região Administrativa"` para `"Região"` na área de filtros do mapa interativo. O objetivo é simplificar e tornar o layout da busca mais limpo e amigável na interface.

### Detalhes técnicos:

#### ⚛️ Frontend
- **Interface e Acessibilidade**: Modificados os textos da `<label>` e o atributo `aria-label` no componente [PainelFiltros.tsx](file:///c:/Users/edson/Desktop/projetos_vscode/2026-1-SafeStreets/frontend/components/PainelFiltros/PainelFiltros.tsx) de `"Região Administrativa"` para `"Região"`.
- **Atualização de Testes**: Ajustadas as asserções de label em [PainelFiltros.test.tsx](file:///c:/Users/edson/Desktop/projetos_vscode/2026-1-SafeStreets/frontend/__tests__/components/PainelFiltros.test.tsx) de forma a procurar pela string `"Região"` nas queries de teste (`getByLabelText`, `findByLabelText`, e asserções do `aria-label`).

---

## 🛠️ Tipo de mudança
- [ ] Bug fix
- [ ] Nova funcionalidade
- [x] Refatoração
- [ ] Documentação
- [ ] Melhoria de performance
- [x] Testes (ajuste de testes existentes)

---

## 🧪 Como testar

1. Faça o checkout para a branch da PR:
   ```bash
   git checkout feat/label-regiao-filtro
   ```
2. Inicie o frontend:
   ```bash
   cd frontend
   npm run dev
   ```
3. Acesse a área do painel de busca/mapa em `http://localhost:3000/mapa` (ou porta ativa).
4. Verifique que a label correspondente ao filtro agora exibe apenas **`Região`** em vez de `Região Administrativa`.

---

## ⚠️ Impactos e riscos
- Risco zero. A mudança é puramente textual na renderização da label e do elemento semântico de acessibilidade do formulário.

---

## ✅ Checklist
- [x] Código segue o padrão do projeto
- [x] Testado localmente
- [x] Testes unitários atualizados e adaptados para a nova string
