### PR TITLE
feat: implementa formatacao inteligente de paragrafos no detalhe da noticia

### DIFF
--- a/frontend/__tests__/view/NoticiaDetalhe.test.tsx
+++ b/frontend/__tests__/view/NoticiaDetalhe.test.tsx
@@ -16,6 +16,9 @@ const noticia: Noticia = {
     "Segundo parágrafo com mais contexto sobre o caso.",
   ],
   fonteUrl: "https://www.ssp.df.gov.br/",
+  risco: "Médio",
+  lat: -15.7942,
+  lng: -47.8822,
 };
 
 describe("NoticiaDetalhe (RF02)", () => {
@@ -79,6 +82,18 @@ describe("NoticiaDetalhe (RF02)", () => {
       expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
         "<script>alert('x')</script>"
       );
+    });
+
+    it("splits paragraphs at each period (.) and groups them into 2-sentence paragraphs, isolating captions and CTAs", () => {
+      const multiSentencas: Noticia = {
+        ...noticia,
+        corpo: ["Primeira sentença. Reprodução Segunda sentença. Terceira. ✅ CTA link."],
+      };
+      render(<NoticiaDetalhe noticia={multiSentencas} />);
+      expect(screen.getByText("Primeira sentença.")).toBeInTheDocument();
+      expect(screen.getByText("Reprodução")).toBeInTheDocument();
+      expect(screen.getByText("Segunda sentença. Terceira.")).toBeInTheDocument();
+      expect(screen.getByText("✅ CTA link.")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/view/NoticiaDetalhe/NoticiaDetalhe.tsx
+++ b/frontend/view/NoticiaDetalhe/NoticiaDetalhe.tsx
@@ -11,6 +11,53 @@ interface NoticiaDetalheProps {
   noticia: Noticia;
 }
 
+function formatarParagrafos(corpo: string[]): string[] {
+  if (corpo.length !== 1) {
+    return corpo;
+  }
+
+  const texto = corpo[0];
+  
+  // Adiciona divisores antes/depois de palavras de legenda comuns (case-insensitive)
+  let processado = texto.replace(/(Reprodução|Foto:|Crédito:)/gi, "\n$1\n");
+  
+  // Adiciona divisor antes de emojis como ✅
+  processado = processado.replace(/(✅)/g, "\n$1");
+  
+  // Adiciona divisores após pontos finais (quando seguidos de espaço)
+  processado = processado.replace(/\.\s+/g, ".\n");
+  
+  const linhas = processado.split("\n").map((l) => l.trim()).filter(Boolean);
+  
+  const novosParagrafos: string[] = [];
+  let bufferFrases: string[] = [];
+  
+  for (const linha of linhas) {
+    const ehLegenda = /^(Reprodução|Foto:|Crédito:)/i.test(linha);
+    const ehCta = /^✅/.test(linha);
+    
+    if (ehLegenda || ehCta) {
+      if (bufferFrases.length > 0) {
+        novosParagrafos.push(bufferFrases.join(" "));
+        bufferFrases = [];
+      }
+      novosParagrafos.push(linha);
+    } else {
+      bufferFrases.push(linha);
+      if (bufferFrases.length >= 2) {
+        novosParagrafos.push(bufferFrases.join(" "));
+        bufferFrases = [];
+      }
+    }
+  }
+  
+  if (bufferFrases.length > 0) {
+    novosParagrafos.push(bufferFrases.join(" "));
+  }
+  
+  return novosParagrafos;
+}
+
 export default function NoticiaDetalhe({ noticia }: NoticiaDetalheProps) {
   return (
     <article className={styles.page}>
@@ -31,7 +78,7 @@ export default function NoticiaDetalhe({ noticia }: NoticiaDetalheProps) {
       <p className={styles.resumo}>{noticia.resumo}</p>
 
       <div className={styles.corpo}>
-        {noticia.corpo.map((paragrafo, indice) => (
+        {formatarParagrafos(noticia.corpo).map((paragrafo, indice) => (
           <p key={indice}>{paragrafo}</p>
         ))}
       </div>


### PR DESCRIPTION
## 📝 Descrição

Este PR implementa uma lógica de formatação e agrupamento inteligente de parágrafos no corpo do detalhamento das notícias. 

Anteriormente, o texto detalhado da notícia era exibido como um bloco único e contínuo no frontend (devido à remoção de tags HTML durante a raspagem no backend). Esse comportamento prejudicava a legibilidade e misturava subtítulos, legendas de imagem (como `"Reprodução"`) e chamadas de ação no mesmo bloco de texto.

### Detalhes técnicos:

#### ⚛️ Frontend
- **Lógica de Parágrafos Inteligentes (`NoticiaDetalhe.tsx`)**: Criada a função `formatarParagrafos` (fallback para notícias com parágrafo único no banco). Ela realiza as seguintes ações:
  - Identifica e isola em parágrafos próprios termos de legenda comuns (`Reprodução`, `Foto:`, `Crédito:`).
  - Identifica e isola chamadas de ação e links externos iniciados com emojis (`✅`).
  - Divide as frases normais nos pontos finais (`. `) e as agrupa em parágrafos contendo no máximo **2 sentenças**, garantindo uma leitura limpa, fluida e similar à formatação original do portal de notícias.
- **Atualização de Testes (`NoticiaDetalhe.test.tsx`)**: Ajustados os tipos do mock de notícia local e adicionado o teste unitário `splits paragraphs at each period (.) and groups them into 2-sentence paragraphs, isolating captions and CTAs` para garantir a integridade da nova lógica de formatação.

---

## 🛠️ Tipo de mudança
- [ ] Bug fix
- [x] Nova funcionalidade
- [x] Refatoração
- [ ] Documentação
- [ ] Melhoria de performance
- [x] Testes (ajuste de testes existentes)

---

## 🧪 Como testar

1. Faça o checkout para a branch da PR:
   ```bash
   git checkout feat/noticias-quebra-paragrafo
   ```
2. Inicie o frontend:
   ```bash
   cd frontend
   npm run dev
   ```
3. Acesse qualquer notícia detalhada (ex: `http://localhost:3000/noticia/39` ou outra de sua escolha).
4. Verifique que a seção de corpo da notícia exibe parágrafos divididos de forma harmônica (de 2 em 2 frases), mantendo o termo **`Reprodução`** e a mensagem do WhatsApp **`✅ Clique aqui...`** destacados em linhas/parágrafos próprios.
5. Execute os testes do componente para garantir o sucesso:
   ```bash
   npx jest __tests__/view/NoticiaDetalhe.test.tsx
   ```

---

## ⚠️ Impactos e riscos
- Risco mínimo. A alteração afeta apenas o processamento de exibição do texto no componente `NoticiaDetalhe` no frontend e possui fallback seguro para não alterar notícias que já venham com parágrafos separados do banco.

---

## ✅ Checklist
- [x] Código segue o padrão do projeto
- [x] Testado localmente
- [x] Testes unitários atualizados e adaptados para a nova lógica
