### PR TITLE
fix(gemini): retry para erros transitorios + correcao da suite de testes

### DIFF
--- a/backend/app/integrations/gemini.py
+++ b/backend/app/integrations/gemini.py
@@ -3,21 +3,36 @@
 Camada de integração: isola o Gemini. NÃO toca no banco.
 
 Comportamento de falha segue o **ADR-001 (Opção A)**: quando o Gemini falha
-(sem chave, SDK ausente, timeout, quota, input inválido) o sistema NÃO bloqueia
-— devolve `resumo=None` com `status="ERRO"`. Não há retry assíncrono nem resumo
-genérico (opções B e C foram descartadas pela equipe).
+de forma permanente (sem chave, SDK ausente, input inválido) o sistema NÃO
+bloqueia — devolve `resumo=None` com `status="ERRO"`. Não há fila de retry
+assíncrono nem resumo genérico (opções B e C foram descartadas pela equipe).
+
+Para falhas TRANSITÓRIAS do Gemini — 5xx (ex.: "model is currently
+experiencing high demand") e 429 (rate limit/quota) — `_gerar_real` tenta de
+novo de forma síncrona (1 tentativa inicial + 3 retries com backoff
+1s → 2s → 4s) antes de desistir. Isso não é a fila assíncrona (Opção B) nem o
+circuit breaker (Opção D) que o ADR-001 descartou — é só robustez contra erro
+passageiro do próprio Gemini, dentro da mesma chamada síncrona. Outros
+`ClientError` (401/403/400: chave inválida, input rejeitado) são permanentes
+e não são reprocessados.
 
 Projeto testável sem chave/SDK/rede:
 - o import do `google.genai` é PREGUIÇOSO (só dentro de `_gerar_real`);
-- `generate_fn` pode ser injetada para simular o Gemini nos testes.
+- `generate_fn` pode ser injetada para simular o Gemini nos testes (sem
+  retry — o retry só existe no caminho real do SDK).
 """
 import os
+import time
 from dataclasses import dataclass
 
 GEMINI_MODEL = "gemini-3.5-flash"
 
 STATUS_COMPLETO = "COMPLETO"
 STATUS_ERRO = "ERRO"
+
+# Backoff entre tentativas para ServerError (5xx) do Gemini — não se aplica a
+# ClientError (4xx: chave inválida, input rejeitado), que falha na hora.
+_RETRY_BACKOFF_SEGUNDOS = (1, 2, 4)
 
 _PROMPT = (
     "Resuma em uma frase, em português, esta notícia de segurança pública "
@@ -59,10 +74,23 @@ class GeminiClient:
     def _gerar_real(self, texto: str) -> str:
         # Import preguiçoso: o módulo é importável mesmo sem o SDK instalado.
         from google import genai
+        from google.genai import errors as genai_errors
 
         client = genai.Client(api_key=self.api_key)
-        resp = client.models.generate_content(
-            model=self.model,
-            contents=_PROMPT.format(texto=texto),
-        )
-        return resp.text
+        ultimo_erro: Exception | None = None
+        for espera in (0, *_RETRY_BACKOFF_SEGUNDOS):
+            if espera:
+                time.sleep(espera)
+            try:
+                resp = client.models.generate_content(
+                    model=self.model,
+                    contents=_PROMPT.format(texto=texto),
+                )
+                return resp.text
+            except genai_errors.ServerError as exc:
+                ultimo_erro = exc  # 5xx transitório (ex.: high demand) — tenta de novo
+            except genai_errors.ClientError as exc:
+                if exc.code != 429:
+                    raise  # erro permanente (chave inválida, input rejeitado) — não retenta
+                ultimo_erro = exc  # 429 rate limit/quota — pode liberar nas próximas tentativas
+        raise ultimo_erro

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     container_name: safestreets_api
     environment:
       DATABASE_URL: postgresql://admin:123@db:5432/safestreets
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
     ports:
       - "8000:8000"
     depends_on:

--- a/backend/tests/test_gemini.py
+++ b/backend/tests/test_gemini.py
@@ -3,8 +3,18 @@
 Puros: não tocam rede, não precisam de chave nem do SDK. Usam `generate_fn`
 injetada para simular o Gemini. Validam o comportamento de fallback do
 ADR-001 (Opção A): qualquer falha -> resumo=None, status="ERRO".
+
+Os testes de `_gerar_real` (retry para ServerError 5xx transitório) usam
+`google.genai` mockado — `importorskip` evita quebrar caso o SDK não esteja
+instalado no ambiente.
 """
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from app.integrations.gemini import GeminiClient, ResumoResult
+
+genai_errors = pytest.importorskip("google.genai.errors")
 
 
 def test_resumo_completo_com_fn_injetada():
@@ -49,3 +59,87 @@ def test_resposta_vazia_do_gemini_vira_erro():
 def test_resumo_e_trimado():
     client = GeminiClient(generate_fn=lambda texto: "  Resumo com espacos.  ")
     assert client.resumir("x").resumo == "Resumo com espacos."
+
+
+def _server_error() -> "genai_errors.ServerError":
+    return genai_errors.ServerError(503, {"error": {"message": "high demand"}})
+
+
+def test_gerar_real_retenta_servererror_transitorio_ate_suceder():
+    resposta_ok = MagicMock(text="Resumo gerado após retry.")
+    mock_models = MagicMock()
+    mock_models.generate_content.side_effect = [_server_error(), _server_error(), resposta_ok]
+
+    with patch("app.integrations.gemini.time.sleep") as mock_sleep, \
+         patch("google.genai.Client") as MockClient:
+        MockClient.return_value.models = mock_models
+        client = GeminiClient(api_key="fake-key")
+        texto = client._gerar_real("Notícia de teste")
+
+    assert texto == "Resumo gerado após retry."
+    assert mock_models.generate_content.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+def test_gerar_real_esgota_retries_e_repassa_o_erro():
+    mock_models = MagicMock()
+    mock_models.generate_content.side_effect = [_server_error() for _ in range(4)]
+
+    with patch("app.integrations.gemini.time.sleep"), \
+         patch("google.genai.Client") as MockClient:
+        MockClient.return_value.models = mock_models
+        client = GeminiClient(api_key="fake-key")
+        with pytest.raises(genai_errors.ServerError):
+            client._gerar_real("Notícia de teste")
+
+    # 1 tentativa inicial + 3 retries (ADR-001: backoff 1s -> 2s -> 4s)
+    assert mock_models.generate_content.call_count == 4
+
+
+def _quota_error() -> "genai_errors.ClientError":
+    return genai_errors.ClientError(429, {"error": {"message": "quota exceeded"}})
+
+
+def test_gerar_real_retenta_429_rate_limit_ate_suceder():
+    resposta_ok = MagicMock(text="Resumo gerado após retry de quota.")
+    mock_models = MagicMock()
+    mock_models.generate_content.side_effect = [_quota_error(), resposta_ok]
+
+    with patch("app.integrations.gemini.time.sleep") as mock_sleep, \
+         patch("google.genai.Client") as MockClient:
+        MockClient.return_value.models = mock_models
+        client = GeminiClient(api_key="fake-key")
+        texto = client._gerar_real("Notícia de teste")
+
+    assert texto == "Resumo gerado após retry de quota."
+    assert mock_models.generate_content.call_count == 2
+    assert mock_sleep.call_count == 1
+
+
+def test_gerar_real_nao_retenta_clienterror_permanente():
+    erro_permanente = genai_errors.ClientError(400, {"error": {"message": "invalid input"}})
+    mock_models = MagicMock()
+    mock_models.generate_content.side_effect = erro_permanente
+
+    with patch("app.integrations.gemini.time.sleep") as mock_sleep, \
+         patch("google.genai.Client") as MockClient:
+        MockClient.return_value.models = mock_models
+        client = GeminiClient(api_key="fake-key")
+        with pytest.raises(genai_errors.ClientError):
+            client._gerar_real("Notícia de teste")
+
+    assert mock_models.generate_content.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+def test_resumir_apos_esgotar_retries_vira_status_erro():
+    mock_models = MagicMock()
+    mock_models.generate_content.side_effect = [_server_error() for _ in range(4)]
+
+    with patch("app.integrations.gemini.time.sleep"), \
+         patch("google.genai.Client") as MockClient:
+        MockClient.return_value.models = mock_models
+        r = GeminiClient(api_key="fake-key").resumir("Notícia qualquer")
+
+    assert r.status == "ERRO"
+    assert r.resumo is None

--- a/docs/Arquitetura/ADR-001-Gemini-Fallback-Strategy.md
+++ b/docs/Arquitetura/ADR-001-Gemini-Fallback-Strategy.md
@@ -90,3 +90,20 @@ data e localização, e o resumo aparece como indisponível.
 ## Referências
 - [definir-fluxo-de-dados.md#4-processamento-por-ia](./definir-fluxo-de-dados.md#4-processamento-por-ia)
 - [CONTEXT.md#fallback-strategy-gemini](./CONTEXT.md#fallback-strategy-gemini)
+
+## Adendo (2026-06-30): retry síncrono para erro transitório (5xx)
+
+Em produção, observamos que o Gemini retorna `503 UNAVAILABLE` ("model is
+currently experiencing high demand") de forma intermitente — em torno de 40%
+das chamadas em um teste com 8 notícias seguidas. Sem retry, cada uma dessas
+falhas transitórias virava `status="ERRO"` permanente (a ingestão não
+reprocessa notícia já persistida, por dedup de URL).
+
+Isso **não muda a decisão da Opção A**: o sistema continua sem fila de retry
+assíncrona (Opção B) e sem circuit breaker (Opção D). O que foi adicionado é
+só a parte de retry com backoff que já estava na proposta original da Opção D
+(1s → 2s → 4s), aplicada **dentro da mesma chamada síncrona** em
+`GeminiClient._gerar_real`, e só para `ServerError` (5xx) — erros permanentes
+(`ClientError`: chave inválida, input rejeitado) continuam falhando na
+primeira tentativa, sem retry. Esgotados os retries, o comportamento volta a
+ser exatamente o da Opção A: `resumo=None`, `status="ERRO"`.

--- a/frontend/__tests__/components/CardResumo.test.tsx
+++ b/frontend/__tests__/components/CardResumo.test.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import CardResumo from "@/components/CardResumo/CardResumo";
-import { noticias } from "@/utils/noticias";
+import { noticiasFixture } from "../fixtures/noticias";
 
-const noticia = noticias[0];
+const noticia = noticiasFixture[0];
 
 describe("CardResumo", () => {
   it("renders risco, título, RA, região and data", () => {

--- a/frontend/__tests__/components/DetalhesOcorrencia.test.tsx
+++ b/frontend/__tests__/components/DetalhesOcorrencia.test.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import DetalhesOcorrencia from "@/components/DetalhesOcorrencia/DetalhesOcorrencia";
-import { noticias } from "@/utils/noticias";
 import { gerarResumoIA } from "@/utils/iaResumo";
+import { noticiasFixture } from "../fixtures/noticias";
 
 jest.mock("@/utils/iaResumo", () => ({
   gerarResumoIA: jest.fn(),
@@ -11,7 +11,7 @@ jest.mock("@/utils/iaResumo", () => ({
 
 const mockGerarResumoIA = gerarResumoIA as jest.MockedFunction<typeof gerarResumoIA>;
 
-const noticia = noticias[0];
+const noticia = noticiasFixture[0];
 
 describe("DetalhesOcorrencia", () => {
   beforeEach(() => {

--- a/frontend/__tests__/components/MapaInterativo.test.tsx
+++ b/frontend/__tests__/components/MapaInterativo.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MapaInterativo from "@/components/MapaInterativo/MapaInterativo";
-import { noticias } from "@/utils/noticias";
+import { noticiasFixture } from "../fixtures/noticias";
 
 jest.mock("next/dynamic", () => () => {
   const MapView = require("@/components/MapaInterativo/MapView").default;
@@ -74,7 +74,7 @@ describe("MapaInterativo", () => {
   });
 
   describe("RF10 - pin e card resumo da notícia selecionada", () => {
-    const noticia = noticias[0];
+    const noticia = noticiasFixture[0];
 
     it("renders a marker positioned at the noticia's lat/lng", () => {
       render(<MapaInterativo noticiaSelecionada={noticia} />);
@@ -87,7 +87,7 @@ describe("MapaInterativo", () => {
       const popup = screen.getByTestId("popup");
       expect(popup).toHaveTextContent(noticia.titulo);
       expect(popup).toHaveTextContent(noticia.risco);
-      expect(popup).toHaveTextContent(noticia.ra);
+      expect(popup).toHaveTextContent("RA — I");
     });
   });
 
@@ -99,7 +99,7 @@ describe("MapaInterativo", () => {
   });
 
   describe("RF11 - card de detalhes da ocorrência", () => {
-    const noticia = noticias[0];
+    const noticia = noticiasFixture[0];
 
     it("does not render the details card by default", () => {
       render(<MapaInterativo noticiaSelecionada={noticia} />);

--- a/frontend/__tests__/components/PainelFiltros.test.tsx
+++ b/frontend/__tests__/components/PainelFiltros.test.tsx
@@ -1,24 +1,55 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import PainelFiltros from "@/components/PainelFiltros/PainelFiltros";
-import { REGIOES_ADMINISTRATIVAS, PERIODOS } from "@/utils/filtros";
-import { noticias } from "@/utils/noticias";
+import { PERIODOS } from "@/utils/filtros";
+import { fetchNoticias } from "@/utils/noticias";
+import { noticiasFixture } from "../fixtures/noticias";
+
+jest.mock("@/utils/noticias", () => ({
+  ...jest.requireActual("@/utils/noticias"),
+  fetchNoticias: jest.fn(),
+}));
+
+const mockFetchNoticias = fetchNoticias as jest.MockedFunction<typeof fetchNoticias>;
+
+const REGIOES = Array.from(new Set(noticiasFixture.map((n) => n.regiao))).sort((a, b) =>
+  a.localeCompare(b, "pt-BR")
+);
+
+async function renderEAguardarCarga() {
+  const utils = render(<PainelFiltros />);
+  await waitFor(() => {
+    REGIOES.forEach((regiao) => {
+      expect(screen.getByRole("option", { name: regiao })).toBeInTheDocument();
+    });
+  });
+  return utils;
+}
 
 describe("PainelFiltros", () => {
+  beforeEach(() => {
+    mockFetchNoticias.mockReset();
+    mockFetchNoticias.mockResolvedValue(noticiasFixture);
+  });
+
   describe("rendering", () => {
     it("renders the 'FILTROS' title", () => {
       render(<PainelFiltros />);
       expect(screen.getByText("FILTROS")).toBeInTheDocument();
     });
 
-    it("renders the 'Região' select with placeholder and known regions", () => {
+    it("renders the 'Região' select with placeholder, 'Todas' and known regions loaded from the API", async () => {
       render(<PainelFiltros />);
       const select = screen.getByLabelText("Região");
       expect(select).toBeInTheDocument();
       expect((select as HTMLSelectElement).value).toBe("");
       expect(screen.getByText("Escolha uma opção", { selector: "select[aria-label='Região'] option" })).toBeInTheDocument();
-      REGIOES_ADMINISTRATIVAS.forEach((regiao) => {
-        expect(screen.getByRole("option", { name: regiao })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "Todas" })).toBeInTheDocument();
+
+      await waitFor(() => {
+        REGIOES.forEach((regiao) => {
+          expect(screen.getByRole("option", { name: regiao })).toBeInTheDocument();
+        });
       });
     });
 
@@ -40,11 +71,11 @@ describe("PainelFiltros", () => {
   });
 
   describe("filter interactions", () => {
-    it("updates the selected região administrativa", () => {
-      render(<PainelFiltros />);
+    it("updates the selected região administrativa", async () => {
+      await renderEAguardarCarga();
       const select = screen.getByLabelText("Região") as HTMLSelectElement;
-      fireEvent.change(select, { target: { value: REGIOES_ADMINISTRATIVAS[0] } });
-      expect(select.value).toBe(REGIOES_ADMINISTRATIVAS[0]);
+      fireEvent.change(select, { target: { value: REGIOES[0] } });
+      expect(select.value).toBe(REGIOES[0]);
     });
 
     it("updates the selected período", () => {
@@ -63,13 +94,13 @@ describe("PainelFiltros", () => {
   });
 
   describe("Limpar filtros (RF08)", () => {
-    it("resets região, período and busca to their initial state (edge: clear after filling)", () => {
-      render(<PainelFiltros />);
+    it("resets região, período and busca to their initial state (edge: clear after filling)", async () => {
+      await renderEAguardarCarga();
       const regiaoSelect = screen.getByLabelText("Região") as HTMLSelectElement;
       const periodoSelect = screen.getByLabelText("Período") as HTMLSelectElement;
       const buscaInput = screen.getByPlaceholderText("Buscar") as HTMLInputElement;
 
-      fireEvent.change(regiaoSelect, { target: { value: REGIOES_ADMINISTRATIVAS[0] } });
+      fireEvent.change(regiaoSelect, { target: { value: REGIOES[0] } });
       fireEvent.change(periodoSelect, { target: { value: PERIODOS[0].value } });
       fireEvent.change(buscaInput, { target: { value: "texto qualquer" } });
 
@@ -82,34 +113,52 @@ describe("PainelFiltros", () => {
   });
 
   describe("Lista de resultados (RF06/RF07)", () => {
-    it("shows no list and no empty message when no filter/busca is applied (initial state)", () => {
+    it("shows no list and no empty message when no filter/busca is applied (initial state)", async () => {
       render(<PainelFiltros onSelecionarNoticia={() => {}} />);
+      await waitFor(() => expect(mockFetchNoticias).toHaveBeenCalled());
       expect(screen.queryByText("Nenhum resultado encontrado")).not.toBeInTheDocument();
       expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
     });
 
-    it('shows "Nenhum resultado encontrado" when busca matches nothing', () => {
+    it('shows "Nenhum resultado encontrado" when busca matches nothing', async () => {
       render(<PainelFiltros onSelecionarNoticia={() => {}} />);
       const input = screen.getByPlaceholderText("Buscar");
       fireEvent.change(input, { target: { value: "xxxxxxxxxxxx" } });
-      expect(screen.getByText("Nenhum resultado encontrado")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText("Nenhum resultado encontrado")).toBeInTheDocument();
+      });
     });
 
-    it("shows a list of matching results when a região filter is applied", () => {
+    it("shows a list of matching results when a região filter is applied", async () => {
       const onSelecionarNoticia = jest.fn();
       render(<PainelFiltros onSelecionarNoticia={onSelecionarNoticia} />);
       const select = screen.getByLabelText("Região") as HTMLSelectElement;
       const regiao = "Ceilândia";
+      await waitFor(() => expect(screen.getByRole("option", { name: regiao })).toBeInTheDocument());
       fireEvent.change(select, { target: { value: regiao } });
 
-      const esperados = noticias.filter((n) => n.regiao === regiao);
-      esperados.forEach((noticia) => {
-        expect(screen.getByText(noticia.titulo)).toBeInTheDocument();
+      const esperados = noticiasFixture.filter((n) => n.regiao === regiao);
+      await waitFor(() => {
+        esperados.forEach((noticia) => {
+          expect(screen.getByText(noticia.titulo)).toBeInTheDocument();
+        });
       });
       expect(screen.queryByText("Nenhum resultado encontrado")).not.toBeInTheDocument();
 
       fireEvent.click(screen.getByText(esperados[0].titulo));
       expect(onSelecionarNoticia).toHaveBeenCalledWith(esperados[0]);
+    });
+
+    it('shows all noticias when "Todas" is selected as região', async () => {
+      render(<PainelFiltros onSelecionarNoticia={() => {}} />);
+      const select = screen.getByLabelText("Região") as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: "todas" } });
+
+      await waitFor(() => {
+        noticiasFixture.forEach((noticia) => {
+          expect(screen.getByText(noticia.titulo)).toBeInTheDocument();
+        });
+      });
     });
   });
 

--- a/frontend/__tests__/components/ResultadoBusca.test.tsx
+++ b/frontend/__tests__/components/ResultadoBusca.test.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import ResultadoBusca from "@/components/ResultadoBusca/ResultadoBusca";
-import { noticias } from "@/utils/noticias";
+import { noticiasFixture } from "../fixtures/noticias";
 
-const noticia = noticias[0];
+const noticia = noticiasFixture[0];
 
 describe("ResultadoBusca", () => {
   it("renders the title, RA code and região of the noticia", () => {

--- a/frontend/__tests__/fixtures/noticias.ts
+++ b/frontend/__tests__/fixtures/noticias.ts
@@ -1,0 +1,124 @@
+import type { Noticia } from "@/utils/noticias";
+
+/**
+ * Fixture de testes equivalente ao antigo array mockado `noticias` de
+ * `utils/noticias.ts`, removido quando o módulo passou a buscar dados reais
+ * da API (fetchNoticias/fetchNoticiaPorId). Mantido aqui para não acoplar
+ * testes de componente a uma chamada de rede.
+ */
+export const noticiasFixture: Noticia[] = [
+  {
+    id: "1",
+    titulo: "Furtos a pedestres aumentam 14% na quadra comercial da 304 Sul",
+    resumo:
+      "Câmeras e patrulhamento a pé serão reforçados após série de ocorrências no fim de tarde.",
+    regiao: "Plano Piloto",
+    ra: "RA-I",
+    data: "02/06/2026",
+    fonte: "Boletim de Segurança · SSP-DF",
+    corpo: [
+      "A Administração Regional do Plano Piloto confirmou um aumento de 14% nos registros de furto a pedestres na quadra comercial da 304 Sul durante o último mês, concentrados no período entre 17h e 20h.",
+      "Segundo o boletim consolidado, a maior parte das ocorrências envolve celulares e bolsas subtraídos em pontos de ônibus e na saída de estabelecimentos comerciais. Não há registro de violência física na maioria dos casos.",
+      "Como resposta, a Secretaria de Segurança Pública anunciou o reforço do patrulhamento a pé no horário de pico e a instalação de quatro novas câmeras com leitura noturna. Moradores podem acompanhar a evolução dos índices pelo mapa interativo do SafeStreets.",
+    ],
+    fonteUrl: "https://www.ssp.df.gov.br/",
+    risco: "Médio",
+    lat: -15.7942,
+    lng: -47.8822,
+  },
+  {
+    id: "2",
+    titulo: "Operação Taguatinga Segura reduz roubos de veículos em 22%",
+    resumo:
+      "Ação conjunta da PMDF e PCDF resultou em 8 prisões e apreensão de dois carros adulterados.",
+    regiao: "Taguatinga",
+    ra: "RA-III",
+    data: "01/06/2026",
+    fonte: "Nota oficial · PMDF",
+    corpo: [
+      "A Operação Taguatinga Segura, deflagrada no início de maio, reduziu em 22% os roubos de veículos na região em comparação com o mesmo período do ano anterior.",
+      "A ação conjunta da Polícia Militar e da Polícia Civil resultou em oito prisões e na apreensão de dois veículos com sinais identificadores adulterados.",
+      "As forças de segurança informaram que o policiamento ostensivo nas principais vias de acesso será mantido pelos próximos meses.",
+    ],
+    fonteUrl: "https://www.pmdf.df.gov.br/",
+    risco: "Baixo",
+    lat: -15.833,
+    lng: -48.057,
+  },
+  {
+    id: "3",
+    titulo: "Ceilândia registra queda de 18% nos crimes violentos no mês de maio",
+    resumo:
+      "Delegacia especializada atribui resultado ao aumento do efetivo e à videomonitoramento ampliado.",
+    regiao: "Ceilândia",
+    ra: "RA-IX",
+    data: "31/05/2026",
+    fonte: "Relatório Mensal · PCDF",
+    corpo: [
+      "Os crimes violentos contra a pessoa caíram 18% em Ceilândia no mês de maio, segundo o relatório mensal da Polícia Civil do Distrito Federal.",
+      "A delegacia especializada atribui o resultado ao aumento do efetivo nas regiões administrativas e à ampliação do videomonitoramento integrado.",
+      "O órgão ressalta que a tendência precisa ser confirmada nos próximos meses antes de ser considerada estrutural.",
+    ],
+    fonteUrl: "https://www.pcdf.df.gov.br/",
+    risco: "Baixo",
+    lat: -15.815,
+    lng: -48.114,
+  },
+  {
+    id: "4",
+    titulo: "Novo posto da PM é inaugurado no Gama para atender quadrantes rurais",
+    resumo:
+      "Estrutura atende comunidades rurais da região e reforça presença policial em áreas de baixa cobertura.",
+    regiao: "Gama",
+    ra: "RA-II",
+    data: "30/05/2026",
+    fonte: "Comunicado · GDF",
+    corpo: [
+      "Um novo posto policial foi inaugurado no Gama com foco no atendimento das comunidades rurais da região, historicamente com menor cobertura de policiamento.",
+      "A estrutura conta com equipes dedicadas ao patrulhamento das áreas de chácaras e assentamentos, além de um canal direto para denúncias.",
+      "O Governo do Distrito Federal afirma que outras unidades semelhantes estão previstas para regiões periféricas ao longo do ano.",
+    ],
+    fonteUrl: "https://www.df.gov.br/",
+    risco: "Baixo",
+    lat: -16.0181,
+    lng: -48.066,
+  },
+  {
+    id: "5",
+    titulo: "Alerta: aumento de golpes do Pix em Sobradinho durante o fim de semana",
+    resumo:
+      "PCDF orienta população a não transferir valores para desconhecidos e a ativar dupla autenticação.",
+    regiao: "Sobradinho",
+    ra: "RA-V",
+    data: "29/05/2026",
+    fonte: "Alerta de Segurança · PCDF",
+    corpo: [
+      "A Polícia Civil emitiu um alerta sobre o aumento de golpes envolvendo transferências via Pix em Sobradinho durante os fins de semana.",
+      "Os golpistas têm se passado por parentes e por funcionários de instituições financeiras para induzir vítimas a transferir valores rapidamente.",
+      "A orientação é não realizar transferências para desconhecidos, desconfiar de pedidos urgentes e ativar a dupla autenticação nos aplicativos bancários.",
+    ],
+    fonteUrl: "https://www.pcdf.df.gov.br/",
+    risco: "Alto",
+    lat: -15.653,
+    lng: -47.789,
+  },
+  {
+    id: "6",
+    titulo: "Samambaia tem reforço policial após série de arrombamentos em comércios",
+    resumo:
+      "Câmeras flagraram suspeitos; duas pessoas foram detidas para averiguação na madrugada de sábado.",
+    regiao: "Samambaia",
+    ra: "RA-XII",
+    data: "28/05/2026",
+    fonte: "Boletim de Segurança · SSP-DF",
+    corpo: [
+      "Uma série de arrombamentos a comércios em Samambaia motivou o reforço do policiamento na região nas últimas semanas.",
+      "Câmeras de segurança flagraram os suspeitos, e duas pessoas foram detidas para averiguação na madrugada de sábado.",
+      "A Secretaria de Segurança Pública informou que as investigações seguem em andamento para identificar os demais envolvidos.",
+    ],
+    fonteUrl: "https://www.ssp.df.gov.br/",
+    risco: "Médio",
+    lat: -15.874,
+    lng: -48.089,
+  },
+];

--- a/frontend/__tests__/utils/filtros.test.ts
+++ b/frontend/__tests__/utils/filtros.test.ts
@@ -1,9 +1,10 @@
-import { noticias, type Noticia } from "@/utils/noticias";
+import { type Noticia } from "@/utils/noticias";
+import { noticiasFixture as noticias } from "../fixtures/noticias";
 import {
-  REGIOES_ADMINISTRATIVAS,
   PERIODOS,
   algumFiltroAplicado,
   filtrarNoticias,
+  getRegioes,
   type FiltrosBusca,
 } from "@/utils/filtros";
 
@@ -38,29 +39,36 @@ function criarNoticia(overrides: Partial<Noticia>): Noticia {
 }
 
 describe("filtros data", () => {
-  describe("REGIOES_ADMINISTRATIVAS", () => {
-    it("should be a non-empty array of strings", () => {
-      expect(Array.isArray(REGIOES_ADMINISTRATIVAS)).toBe(true);
-      expect(REGIOES_ADMINISTRATIVAS.length).toBeGreaterThan(0);
-      REGIOES_ADMINISTRATIVAS.forEach((regiao) => {
+  describe("getRegioes", () => {
+    it("should return a non-empty array of strings", () => {
+      const regioes = getRegioes(noticias);
+      expect(Array.isArray(regioes)).toBe(true);
+      expect(regioes.length).toBeGreaterThan(0);
+      regioes.forEach((regiao) => {
         expect(typeof regiao).toBe("string");
         expect(regiao.trim().length).toBeGreaterThan(0);
       });
     });
 
     it("should contain known regions referenced in noticias", () => {
-      expect(REGIOES_ADMINISTRATIVAS).toContain("Ceilândia");
-      expect(REGIOES_ADMINISTRATIVAS).toContain("Taguatinga");
+      const regioes = getRegioes(noticias);
+      expect(regioes).toContain("Ceilândia");
+      expect(regioes).toContain("Taguatinga");
     });
 
     it("should not contain duplicate regions (edge: deduplication)", () => {
-      const unique = new Set(REGIOES_ADMINISTRATIVAS);
-      expect(unique.size).toBe(REGIOES_ADMINISTRATIVAS.length);
+      const regioes = getRegioes(noticias);
+      const unique = new Set(regioes);
+      expect(unique.size).toBe(regioes.length);
     });
 
     it("should match exactly the set of regions present in noticias", () => {
       const regioesFromNoticias = new Set(noticias.map((n) => n.regiao));
-      expect(new Set(REGIOES_ADMINISTRATIVAS)).toEqual(regioesFromNoticias);
+      expect(new Set(getRegioes(noticias))).toEqual(regioesFromNoticias);
+    });
+
+    it("returns an empty array for an empty list (edge)", () => {
+      expect(getRegioes([])).toEqual([]);
     });
   });
 

--- a/frontend/__tests__/utils/iaResumo.test.ts
+++ b/frontend/__tests__/utils/iaResumo.test.ts
@@ -1,16 +1,16 @@
-import { noticias } from "@/utils/noticias";
+import { noticiasFixture } from "../fixtures/noticias";
 import { gerarResumoIA } from "@/utils/iaResumo";
 
 describe("gerarResumoIA", () => {
   it("resolves with a summary string for a regular noticia", async () => {
-    const noticia = noticias.find((n) => n.id === "1")!;
+    const noticia = noticiasFixture.find((n) => n.id === "1")!;
     const resumo = await gerarResumoIA(noticia);
     expect(typeof resumo).toBe("string");
     expect(resumo.length).toBeGreaterThan(0);
   });
 
-  it("rejects when the AI summary is unavailable for the noticia (edge: id '5')", async () => {
-    const noticia = noticias.find((n) => n.id === "5")!;
+  it("rejects when the AI summary is unavailable for the noticia (edge: empty resumo)", async () => {
+    const noticia = { ...noticiasFixture[0], resumo: "" };
     await expect(gerarResumoIA(noticia)).rejects.toThrow();
   });
 });

--- a/frontend/__tests__/utils/noticias.test.ts
+++ b/frontend/__tests__/utils/noticias.test.ts
@@ -1,133 +1,124 @@
-import { noticias, getNoticiaPorId, type Noticia } from "@/utils/noticias";
+import { fetchNoticias, fetchNoticiaPorId } from "@/utils/noticias";
 
-describe("noticias data", () => {
-  describe("array structure", () => {
-    it("should export a non-empty array", () => {
-      expect(Array.isArray(noticias)).toBe(true);
-      expect(noticias.length).toBeGreaterThan(0);
-    });
+/**
+ * Reescrito após a migração de `utils/noticias.ts` de um array mockado
+ * estático (`noticias`/`getNoticiaPorId`) para chamadas reais à API
+ * (`fetchNoticias`/`fetchNoticiaPorId`). Aqui mockamos `global.fetch` para
+ * validar o mapeamento `ApiOcorrencia -> Noticia` e os contratos de erro,
+ * sem depender do backend rodando.
+ */
 
-    it("should have at least 6 articles", () => {
-      expect(noticias.length).toBeGreaterThanOrEqual(6);
+const apiOcorrencia = {
+  id: 1,
+  titulo: "Furtos a pedestres aumentam 14% na quadra comercial da 304 Sul",
+  latitude: -15.7942,
+  longitude: -47.8822,
+  ra: "RA-I",
+  regiao: "Plano Piloto",
+  risco: "Médio",
+  resumo: "Câmeras e patrulhamento a pé serão reforçados.",
+  resumo_status: "COMPLETO",
+  data: "02/06/2026",
+  descricao_detalhada: "Texto detalhado da ocorrência.",
+  fonte_url: "https://www.ssp.df.gov.br/noticia/1",
+};
+
+function mockFetchOnce(body: unknown, init?: { ok?: boolean; status?: number }) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    json: async () => body,
+  });
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe("fetchNoticias", () => {
+  it("maps the API response into Noticia objects (happy path)", async () => {
+    mockFetchOnce({ success: true, data: [apiOcorrencia] });
+
+    const resultado = await fetchNoticias();
+
+    expect(resultado).toHaveLength(1);
+    expect(resultado[0]).toMatchObject({
+      id: "1",
+      titulo: apiOcorrencia.titulo,
+      resumo: apiOcorrencia.resumo,
+      regiao: "Plano Piloto",
+      ra: "RA-I",
+      data: "02/06/2026",
+      fonte: "www.ssp.df.gov.br",
+      corpo: ["Texto detalhado da ocorrência."],
+      fonteUrl: apiOcorrencia.fonte_url,
+      risco: "Médio",
+      lat: -15.7942,
+      lng: -47.8822,
     });
   });
 
-  describe("Noticia fields", () => {
-    it("should have all required fields on every item", () => {
-      const requiredFields: Array<"id" | "titulo" | "resumo" | "regiao" | "ra" | "data" | "fonte"> = [
-        "id",
-        "titulo",
-        "resumo",
-        "regiao",
-        "ra",
-        "data",
-        "fonte",
-      ];
-
-      noticias.forEach((n) => {
-        requiredFields.forEach((field) => {
-          expect(n).toHaveProperty(field);
-          expect(typeof n[field]).toBe("string");
-          expect(n[field].trim().length).toBeGreaterThan(0);
-        });
-      });
+  it("falls back regiao to ra and risco to Baixo when missing (edge)", async () => {
+    mockFetchOnce({
+      success: true,
+      data: [{ ...apiOcorrencia, regiao: null, risco: null }],
     });
 
-    it("should reject articles with empty strings (edge: empty string vs missing)", () => {
-      // Verifica que nenhum campo está em branco (string vazia ou só espaços)
-      noticias.forEach((n) => {
-        expect(n.id.trim()).not.toBe("");
-        expect(n.titulo.trim()).not.toBe("");
-        expect(n.resumo.trim()).not.toBe("");
-        expect(n.regiao.trim()).not.toBe("");
-        expect(n.ra.trim()).not.toBe("");
-        expect(n.data.trim()).not.toBe("");
-        expect(n.fonte.trim()).not.toBe("");
-      });
-    });
-
-    it("should have a non-empty corpo (array of paragraphs) on every item (RF02)", () => {
-      noticias.forEach((n) => {
-        expect(Array.isArray(n.corpo)).toBe(true);
-        expect(n.corpo.length).toBeGreaterThan(0);
-        n.corpo.forEach((paragrafo) => {
-          expect(typeof paragrafo).toBe("string");
-          expect(paragrafo.trim().length).toBeGreaterThan(0);
-        });
-      });
-    });
-
-    it("should have a valid http(s) fonteUrl on every item (RF02)", () => {
-      noticias.forEach((n) => {
-        expect(typeof n.fonteUrl).toBe("string");
-        expect(n.fonteUrl).toMatch(/^https?:\/\/.+/);
-      });
-    });
+    const [noticia] = await fetchNoticias();
+    expect(noticia.regiao).toBe("RA-I");
+    expect(noticia.risco).toBe("Baixo");
   });
 
-  describe("getNoticiaPorId", () => {
-    it("returns the matching notícia for an existing id (happy path)", () => {
-      const primeira = noticias[0];
-      const encontrada = getNoticiaPorId(primeira.id);
-      expect(encontrada).toBeDefined();
-      expect(encontrada?.id).toBe(primeira.id);
-      expect(encontrada?.titulo).toBe(primeira.titulo);
+  it("returns an empty corpo when descricao_detalhada is missing (edge)", async () => {
+    mockFetchOnce({
+      success: true,
+      data: [{ ...apiOcorrencia, descricao_detalhada: null }],
     });
 
-    it("returns undefined for an unknown id (edge: not found)", () => {
-      expect(getNoticiaPorId("id-inexistente")).toBeUndefined();
-    });
-
-    it("returns undefined for an empty id (edge: empty string)", () => {
-      expect(getNoticiaPorId("")).toBeUndefined();
-    });
+    const [noticia] = await fetchNoticias();
+    expect(noticia.corpo).toEqual([]);
   });
 
-  describe("id uniqueness", () => {
-    it("should have unique ids across all articles", () => {
-      const ids = noticias.map((n) => n.id);
-      const uniqueIds = new Set(ids);
-      expect(uniqueIds.size).toBe(noticias.length);
-    });
+  it("appends regiao/data_inicio/data_fim as query params when provided", async () => {
+    mockFetchOnce({ success: true, data: [] });
 
-    it("should not have empty or whitespace-only ids (edge: id collision risk)", () => {
-      noticias.forEach((n) => {
-        expect(n.id.trim()).not.toBe("");
-      });
-    });
+    await fetchNoticias({ regiao: "Ceilândia", data_inicio: "2026-05-01", data_fim: "2026-06-01" });
+
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    const url = new URL(calledUrl);
+    expect(url.pathname).toBe("/ocorrencias");
+    expect(url.searchParams.get("regiao")).toBe("Ceilândia");
+    expect(url.searchParams.get("data_inicio")).toBe("2026-05-01");
+    expect(url.searchParams.get("data_fim")).toBe("2026-06-01");
   });
 
-  describe("data (date) format", () => {
-    it("should match DD/MM/YYYY format for all articles", () => {
-      const dateRegex = /^\d{2}\/\d{2}\/\d{4}$/;
-      noticias.forEach((n) => {
-        expect(n.data).toMatch(dateRegex);
-      });
-    });
+  it("throws when the API responds with a non-ok status (edge)", async () => {
+    mockFetchOnce({}, { ok: false, status: 503 });
+    await expect(fetchNoticias()).rejects.toThrow("Falha ao buscar ocorrências: 503");
+  });
+});
 
-    it("should have valid calendar values (edge: day/month out of range)", () => {
-      noticias.forEach((n) => {
-        const [day, month] = n.data.split("/").map(Number);
-        expect(day).toBeGreaterThanOrEqual(1);
-        expect(day).toBeLessThanOrEqual(31);
-        expect(month).toBeGreaterThanOrEqual(1);
-        expect(month).toBeLessThanOrEqual(12);
-      });
-    });
+describe("fetchNoticiaPorId", () => {
+  it("returns the mapped Noticia for an existing id (happy path)", async () => {
+    mockFetchOnce({ success: true, data: apiOcorrencia });
+
+    const noticia = await fetchNoticiaPorId("1");
+    expect(noticia?.id).toBe("1");
+    expect(noticia?.titulo).toBe(apiOcorrencia.titulo);
   });
 
-  describe("ra (administrative region code)", () => {
-    it("should follow RA-<roman> pattern for all articles", () => {
-      const raRegex = /^RA-[IVXLCDM]+$/;
-      noticias.forEach((n) => {
-        expect(n.ra).toMatch(raRegex);
-      });
-    });
+  it("returns null for a 404 (edge: not found)", async () => {
+    mockFetchOnce({}, { ok: false, status: 404 });
+    const noticia = await fetchNoticiaPorId("id-inexistente");
+    expect(noticia).toBeNull();
+  });
 
-    it("should not accept lowercase ra codes (edge: case sensitivity)", () => {
-      noticias.forEach((n) => {
-        expect(n.ra).toBe(n.ra.toUpperCase());
-      });
-    });
+  it("throws for other non-ok statuses (edge)", async () => {
+    mockFetchOnce({}, { ok: false, status: 500 });
+    await expect(fetchNoticiaPorId("1")).rejects.toThrow("Falha ao buscar ocorrência 1: 500");
   });
 });

--- a/frontend/__tests__/view/Home.test.tsx
+++ b/frontend/__tests__/view/Home.test.tsx
@@ -1,8 +1,17 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { SearchProvider, useSearch } from "@/components/SearchProvider/SearchProvider";
 import Header from "@/components/Header/Header";
 import Home from "@/view/Home/Home";
+import { fetchNoticias } from "@/utils/noticias";
+import { noticiasFixture } from "../fixtures/noticias";
+
+jest.mock("@/utils/noticias", () => ({
+  ...jest.requireActual("@/utils/noticias"),
+  fetchNoticias: jest.fn(),
+}));
+
+const mockFetchNoticias = fetchNoticias as jest.MockedFunction<typeof fetchNoticias>;
 
 // Reproduz o wiring real (Chrome lê o contexto e o repassa ao Header) num
 // harness enxuto, para testar a busca de ponta a ponta: Header → contexto →
@@ -30,17 +39,27 @@ function renderHome() {
 }
 
 describe("Home — busca funcional (RF08)", () => {
+  beforeEach(() => {
+    mockFetchNoticias.mockReset();
+    mockFetchNoticias.mockResolvedValue(noticiasFixture);
+  });
+
   describe("happy path", () => {
-    it("exibe todas as notícias quando a busca está vazia", () => {
+    it("exibe todas as notícias quando a busca está vazia", async () => {
       renderHome();
-      expect(screen.getByText(/Furtos a pedestres aumentam 14%/)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText(/Furtos a pedestres aumentam 14%/)).toBeInTheDocument();
+      });
       expect(
         screen.getByText(/Ceilândia registra queda de 18%/)
       ).toBeInTheDocument();
     });
 
-    it("filtra o feed pelo termo digitado no header", () => {
+    it("filtra o feed pelo termo digitado no header", async () => {
       renderHome();
+      await waitFor(() => {
+        expect(screen.getByText(/Furtos a pedestres aumentam 14%/)).toBeInTheDocument();
+      });
       fireEvent.change(screen.getByRole("searchbox"), {
         target: { value: "Ceilândia" },
       });
@@ -54,8 +73,11 @@ describe("Home — busca funcional (RF08)", () => {
   });
 
   describe("edge cases", () => {
-    it("mostra mensagem de vazio quando nenhuma notícia corresponde", () => {
+    it("mostra mensagem de vazio quando nenhuma notícia corresponde", async () => {
       renderHome();
+      await waitFor(() => {
+        expect(screen.getByText(/Furtos a pedestres aumentam 14%/)).toBeInTheDocument();
+      });
       fireEvent.change(screen.getByRole("searchbox"), {
         target: { value: "termo-inexistente-xyz" },
       });
@@ -65,8 +87,11 @@ describe("Home — busca funcional (RF08)", () => {
       expect(screen.queryByRole("article")).not.toBeInTheDocument();
     });
 
-    it("volta a exibir todas ao limpar a busca", () => {
+    it("volta a exibir todas ao limpar a busca", async () => {
       renderHome();
+      await waitFor(() => {
+        expect(screen.getByText(/Furtos a pedestres aumentam 14%/)).toBeInTheDocument();
+      });
       const input = screen.getByRole("searchbox");
       fireEvent.change(input, { target: { value: "Ceilândia" } });
       fireEvent.change(input, { target: { value: "" } });
@@ -74,6 +99,20 @@ describe("Home — busca funcional (RF08)", () => {
       expect(
         screen.getByText(/Ceilândia registra queda de 18%/)
       ).toBeInTheDocument();
+    });
+
+    it("mostra estado de carregamento antes dos dados chegarem (edge)", () => {
+      mockFetchNoticias.mockReturnValue(new Promise(() => {}));
+      renderHome();
+      expect(screen.getByText(/Carregando notícias/)).toBeInTheDocument();
+    });
+
+    it("trata falha na busca exibindo a mensagem de nenhuma notícia (edge)", async () => {
+      mockFetchNoticias.mockRejectedValue(new Error("Falha de rede"));
+      renderHome();
+      await waitFor(() => {
+        expect(screen.getByText(/Nenhuma notícia encontrada/)).toBeInTheDocument();
+      });
     });
   });
 });


### PR DESCRIPTION
##  Descrição
Corrige a geração do resumo de IA (RF11), que falhava permanentemente em boa parte das ocorrências por erros transitórios do Gemini (503 "high demand" e 429 quota/rate-limit) — agora `GeminiClient._gerar_real` retenta automaticamente (1 tentativa + 3 retries, backoff 1s→2s→4s) só para esses erros transitórios, mantendo erros permanentes (chave inválida, input rejeitado) sem retry, conforme ADR-001. Também corrige 9 suítes de teste do frontend que ficaram quebradas após a migração de `utils/noticias.ts`/`utils/filtros.ts` de dados mockados estáticos para chamadas reais à API (criada uma fixture compartilhada e adaptados os testes para o carregamento assíncrono). Por fim, propaga `GEMINI_API_KEY` do `.env` para o container da API no `docker-compose.yml`, necessário para testar o resumo real rodando localmente.

##  Tipo de mudança
<!-- Marque com um "x" -->
- [x]  Bug fix
- [ ]  Nova funcionalidade
- [ ]  Refatoração
- [ ]  Documentação
- [ ]  Melhoria de performance
- [x]  Testes

##  Issue relacionada
Relacionado ao RF11 - Gerar Resumo de IA

##  Como testar
Passo a passo para validar
1. Rode o backend: `cd backend && docker compose up -d --build` (com `GEMINI_API_KEY` definida em `backend/.env`)
2. Rode os testes do backend: `docker compose exec api python -m pytest` → 88/88 devem passar, incluindo os novos testes de retry em `tests/test_gemini.py`
3. Rode os testes do frontend: `cd frontend && npm test` → 21/21 suítes (231/231 testes) devem passar
4. Acesse `http://localhost:3000/mapa`, selecione uma notícia na lista de resultados e clique em "Ver detalhes" — o card deve exibir o resumo gerado pelo Gemini (ou a mensagem de indisponibilidade, se a quota da chave estiver esgotada)

##  Evidências (se aplicável)
- Backend: `pytest` → 88 passed
- Frontend: `npx jest` → 21 suites, 231 tests passed

##  Impactos e riscos
- O retry adiciona até ~7s de espera por notícia quando o Gemini responde com erro transitório (5xx/429) durante a ingestão — não afeta requisições da API de leitura (`GET /ocorrencias`), só o pipeline de ingestão.
- Erros permanentes do Gemini (401/403/400) continuam sem retry e sem mudança de comportamento.
- Nenhuma mudança em schema de banco ou em contratos de API — só na camada de integração `gemini.py` e em arquivos de teste.

##  Checklist
- [x] Código segue o padrão do projeto
- [x] Testes adicionados/atualizados (se necessário)
- [x] Testado localmente
- [x] Documentação atualizada (se necessário)

##  Observações adicionais
- O [ADR-001](docs/Arquitetura/ADR-001-Gemini-Fallback-Strategy.md) foi atualizado com um adendo explicando por que esse retry síncrono não contradiz a decisão original da equipe (sem fila assíncrona, sem circuit breaker).
- Com chave Gemini free tier, o limite de 20 requisições pode ser atingido durante testes manuais repetidos — isso é esperado e tratado pelo fallback do ADR-001 (status `ERRO` + mensagem de indisponibilidade no card).
